### PR TITLE
Do not use chart repo id in search url params

### DIFF
--- a/cmd/hub/handlers.go
+++ b/cmd/hub/handlers.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cncf/hub/internal/hub"
 	"github.com/cncf/hub/internal/img/pg"
-	"github.com/google/uuid"
 	svg "github.com/h2non/go-is-svg"
 	"github.com/jackc/pgx/v4"
 	"github.com/julienschmidt/httprouter"
@@ -184,18 +183,18 @@ func buildQuery(qs url.Values) (*hub.Query, error) {
 	// Repos
 	repos := qs["repo"]
 	for _, repo := range repos {
-		if _, err := uuid.Parse(repo); err != nil {
+		if repo == "" {
 			return nil, fmt.Errorf("invalid repo: %s", repo)
 		}
 	}
 
 	return &hub.Query{
-		Limit:                limit,
-		Offset:               offset,
-		Facets:               facets,
-		Text:                 text,
-		PackageKinds:         kinds,
-		ChartRepositoriesIDs: repos,
+		Limit:             limit,
+		Offset:            offset,
+		Facets:            facets,
+		Text:              text,
+		PackageKinds:      kinds,
+		ChartRepositories: repos,
 	}, nil
 }
 

--- a/cmd/hub/handlers_test.go
+++ b/cmd/hub/handlers_test.go
@@ -167,7 +167,7 @@ func TestSearch(t *testing.T) {
 			{"invalid facets", "facets=z"},
 			{"invalid kind", "kind=z"},
 			{"invalid kind (one of them)", "kind=0&kind=z"},
-			{"invalid repo", "repo=repo1"},
+			{"invalid repo", "repo="},
 		}
 		for _, tc := range badRequests {
 			tc := tc

--- a/database/tests/functions/search_packages.sql
+++ b/database/tests/functions/search_packages.sql
@@ -155,7 +155,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -168,7 +167,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 2",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000002",
                     "name": "repo2",
                     "display_name": "Repo 2"
                 }
@@ -199,7 +197,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -212,7 +209,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 2",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000002",
                     "name": "repo2",
                     "display_name": "Repo 2"
                 }
@@ -229,11 +225,11 @@ select is(
                 "title": "Repository",
                 "filter_key": "repo",
                 "options": [{
-                    "id": "00000000-0000-0000-0000-000000000001",
+                    "id": "repo1",
                     "name": "Repo1",
                     "total": 1
                 }, {
-                    "id": "00000000-0000-0000-0000-000000000002",
+                    "id": "repo2",
                     "name": "Repo2",
                     "total": 1
                 }]
@@ -263,7 +259,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -280,7 +275,7 @@ select is(
                 "title": "Repository",
                 "filter_key": "repo",
                 "options": [{
-                    "id": "00000000-0000-0000-0000-000000000001",
+                    "id": "repo1",
                     "name": "Repo1",
                     "total": 1
                 }]
@@ -315,8 +310,8 @@ select is(
 -- Tests with kind and repositories filters
 select is(
     search_packages('{
-        "chart_repositories_ids": [
-            "00000000-0000-0000-0000-000000000001"
+        "chart_repositories": [
+            "repo1"
         ]
     }')::jsonb,
     '{
@@ -330,7 +325,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -348,8 +342,8 @@ select is(
 select is(
     search_packages('{
         "text": "",
-        "chart_repositories_ids": [
-            "00000000-0000-0000-0000-000000000001"
+        "chart_repositories": [
+            "repo1"
         ]
     }')::jsonb,
     '{
@@ -363,7 +357,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -383,8 +376,8 @@ select is(
     '{
         "facets": true,
         "text": "kw1",
-        "chart_repositories_ids": [
-            "00000000-0000-0000-0000-000000000002"
+        "chart_repositories": [
+            "repo2"
         ]
     }')::jsonb,
     '{
@@ -398,7 +391,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 2",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000002",
                     "name": "repo2",
                     "display_name": "Repo 2"
                 }
@@ -415,11 +407,11 @@ select is(
                 "title": "Repository",
                 "filter_key": "repo",
                 "options": [{
-                    "id": "00000000-0000-0000-0000-000000000001",
+                    "id": "repo1",
                     "name": "Repo1",
                     "total": 1
                 }, {
-                    "id": "00000000-0000-0000-0000-000000000002",
+                    "id": "repo2",
                     "name": "Repo2",
                     "total": 1
                 }]
@@ -437,8 +429,8 @@ select is(
     search_packages('{
         "facets": true,
         "text": "kw1",
-        "chart_repositories_ids": [
-            "00000000-0000-0000-0000-000000000003"
+        "chart_repositories": [
+            "repo3"
         ]
     }')::jsonb,
     '{
@@ -456,11 +448,11 @@ select is(
                 "title": "Repository",
                 "filter_key": "repo",
                 "options": [{
-                    "id": "00000000-0000-0000-0000-000000000001",
+                    "id": "repo1",
                     "name": "Repo1",
                     "total": 1
                 }, {
-                    "id": "00000000-0000-0000-0000-000000000002",
+                    "id": "repo2",
                     "name": "Repo2",
                     "total": 1
                 }]
@@ -512,7 +504,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -525,7 +516,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 2",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000002",
                     "name": "repo2",
                     "display_name": "Repo 2"
                 }
@@ -557,7 +547,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 1",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000001",
                     "name": "repo1",
                     "display_name": "Repo 1"
                 }
@@ -608,7 +597,6 @@ select is(
                 "description": "description",
                 "display_name": "Package 2",
                 "chart_repository": {
-                    "chart_repository_id": "00000000-0000-0000-0000-000000000002",
                     "name": "repo2",
                     "display_name": "Repo 2"
                 }
@@ -664,11 +652,11 @@ select is(
                 "title": "Repository",
                 "filter_key": "repo",
                 "options": [{
-                    "id": "00000000-0000-0000-0000-000000000001",
+                    "id": "repo1",
                     "name": "Repo1",
                     "total": 1
                 }, {
-                    "id": "00000000-0000-0000-0000-000000000002",
+                    "id": "repo2",
                     "name": "Repo2",
                     "total": 1
                 }]

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/go-openapi/spec v0.19.4 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
-	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f // indirect
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c

--- a/internal/hub/types.go
+++ b/internal/hub/types.go
@@ -83,12 +83,12 @@ type Package struct {
 
 // Query represents the query used when searching for packages.
 type Query struct {
-	Limit                int           `json:"limit,omitempty"`
-	Offset               int           `json:"offset,omitempty"`
-	Facets               bool          `json:"facets"`
-	Text                 string        `json:"text"`
-	PackageKinds         []PackageKind `json:"package_kinds,omitempty"`
-	ChartRepositoriesIDs []string      `json:"chart_repositories_ids,omitempty"`
+	Limit             int           `json:"limit,omitempty"`
+	Offset            int           `json:"offset,omitempty"`
+	Facets            bool          `json:"facets"`
+	Text              string        `json:"text"`
+	PackageKinds      []PackageKind `json:"package_kinds,omitempty"`
+	ChartRepositories []string      `json:"chart_repositories,omitempty"`
 }
 
 // GetPackageInput represents the input used to get a specific package.

--- a/web/src/layout/home/PackageCard.tsx
+++ b/web/src/layout/home/PackageCard.tsx
@@ -57,7 +57,7 @@ const PackageCard = (props: Props) => {
                                     search: prepareQueryString({
                                       pageNumber: 1,
                                       filters: {
-                                        'repo': [props.package.chartRepository!.chartRepositoryId!],
+                                        'repo': [props.package.chartRepository!.name],
                                       },
                                     }),
                                   });

--- a/web/src/layout/home/__fixtures__/packagesUpdates/1.json
+++ b/web/src/layout/home/__fixtures__/packagesUpdates/1.json
@@ -8,7 +8,6 @@
             "logoImageId": "aca0e134-7e18-411c-9662-1245f92f438d",
             "appVersion": "1.6.8",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -21,7 +20,6 @@
             "logoImageId": "18db8f84-f8a7-4203-9116-60f24d34914f",
             "appVersion": "4.3.2-1",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -34,7 +32,6 @@
             "logoImageId": null,
             "appVersion": "1.17.8",
             "chartRepository": {
-                "chartRepositoryId": "f34e1c55-a4f9-4fa7-aef6-416afcce0810",
                 "name": "gabibbo97",
                 "displayName": null
             }
@@ -47,7 +44,6 @@
             "logoImageId": "56724a8a-d8de-4700-8f23-1cf828220d51",
             "appVersion": "latest",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -60,7 +56,6 @@
             "logoImageId": "2fbaacae-e538-4706-a9fc-bcf443218af1",
             "appVersion": "1.0",
             "chartRepository": {
-                "chartRepositoryId": "77cd4586-0551-4e80-be64-cddca21c2d3b",
                 "name": "billimek",
                 "displayName": null
             }
@@ -75,7 +70,6 @@
             "logoImageId": "b8a744f8-5bdc-4b2c-9bc7-295fe0d6b449",
             "appVersion": "lts",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -88,7 +82,6 @@
             "logoImageId": "af1bf4f3-e422-4de5-a023-ca5ad911e228",
             "appVersion": "1.10.4",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -101,7 +94,6 @@
             "logoImageId": null,
             "appVersion": "0.27.5",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -114,7 +106,6 @@
             "logoImageId": null,
             "appVersion": "1.14.6",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -127,7 +118,6 @@
             "logoImageId": "61c68f47-1ec8-42fe-a108-959644f148b0",
             "appVersion": "1.3.3.22",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }

--- a/web/src/layout/home/__fixtures__/packagesUpdates/2.json
+++ b/web/src/layout/home/__fixtures__/packagesUpdates/2.json
@@ -8,7 +8,6 @@
             "logoImageId": "aca0e134-7e18-411c-9662-1245f92f438d",
             "appVersion": "1.6.8",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -21,7 +20,6 @@
             "logoImageId": "18db8f84-f8a7-4203-9116-60f24d34914f",
             "appVersion": "4.3.2-1",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -34,7 +32,6 @@
             "logoImageId": null,
             "appVersion": "1.17.8",
             "chartRepository": {
-                "chartRepositoryId": "f34e1c55-a4f9-4fa7-aef6-416afcce0810",
                 "name": "gabibbo97",
                 "displayName": null
             }
@@ -47,7 +44,6 @@
             "logoImageId": "56724a8a-d8de-4700-8f23-1cf828220d51",
             "appVersion": "latest",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -60,7 +56,6 @@
             "logoImageId": "2fbaacae-e538-4706-a9fc-bcf443218af1",
             "appVersion": "1.0",
             "chartRepository": {
-                "chartRepositoryId": "77cd4586-0551-4e80-be64-cddca21c2d3b",
                 "name": "billimek",
                 "displayName": null
             }
@@ -75,7 +70,6 @@
             "logoImageId": "b8a744f8-5bdc-4b2c-9bc7-295fe0d6b449",
             "appVersion": "lts",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -88,7 +82,6 @@
             "logoImageId": "af1bf4f3-e422-4de5-a023-ca5ad911e228",
             "appVersion": "1.10.4",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -101,7 +94,6 @@
             "logoImageId": null,
             "appVersion": "0.27.5",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -114,7 +106,6 @@
             "logoImageId": null,
             "appVersion": "1.14.6",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -127,7 +118,6 @@
             "logoImageId": "61c68f47-1ec8-42fe-a108-959644f148b0",
             "appVersion": "1.3.3.22",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }

--- a/web/src/layout/home/__fixtures__/packagesUpdates/3.json
+++ b/web/src/layout/home/__fixtures__/packagesUpdates/3.json
@@ -8,7 +8,6 @@
             "logoImageId": "aca0e134-7e18-411c-9662-1245f92f438d",
             "appVersion": "1.6.8",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -21,7 +20,6 @@
             "logoImageId": "18db8f84-f8a7-4203-9116-60f24d34914f",
             "appVersion": "4.3.2-1",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -34,7 +32,6 @@
             "logoImageId": null,
             "appVersion": "1.17.8",
             "chartRepository": {
-                "chartRepositoryId": "f34e1c55-a4f9-4fa7-aef6-416afcce0810",
                 "name": "gabibbo97",
                 "displayName": null
             }
@@ -47,7 +44,6 @@
             "logoImageId": "56724a8a-d8de-4700-8f23-1cf828220d51",
             "appVersion": "latest",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -60,7 +56,6 @@
             "logoImageId": "2fbaacae-e538-4706-a9fc-bcf443218af1",
             "appVersion": "1.0",
             "chartRepository": {
-                "chartRepositoryId": "77cd4586-0551-4e80-be64-cddca21c2d3b",
                 "name": "billimek",
                 "displayName": null
             }
@@ -75,7 +70,6 @@
             "logoImageId": "b8a744f8-5bdc-4b2c-9bc7-295fe0d6b449",
             "appVersion": "lts",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -88,7 +82,6 @@
             "logoImageId": "af1bf4f3-e422-4de5-a023-ca5ad911e228",
             "appVersion": "1.10.4",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -101,7 +94,6 @@
             "logoImageId": null,
             "appVersion": "0.27.5",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -114,7 +106,6 @@
             "logoImageId": null,
             "appVersion": "1.14.6",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -127,7 +118,6 @@
             "logoImageId": "61c68f47-1ec8-42fe-a108-959644f148b0",
             "appVersion": "1.3.3.22",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }

--- a/web/src/layout/home/__fixtures__/packagesUpdates/4.json
+++ b/web/src/layout/home/__fixtures__/packagesUpdates/4.json
@@ -8,7 +8,6 @@
             "logoImageId": "aca0e134-7e18-411c-9662-1245f92f438d",
             "appVersion": "1.6.8",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -21,7 +20,6 @@
             "logoImageId": "18db8f84-f8a7-4203-9116-60f24d34914f",
             "appVersion": "4.3.2-1",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -34,7 +32,6 @@
             "logoImageId": null,
             "appVersion": "1.17.8",
             "chartRepository": {
-                "chartRepositoryId": "f34e1c55-a4f9-4fa7-aef6-416afcce0810",
                 "name": "gabibbo97",
                 "displayName": null
             }
@@ -47,7 +44,6 @@
             "logoImageId": "56724a8a-d8de-4700-8f23-1cf828220d51",
             "appVersion": "latest",
             "chartRepository": {
-                "chartRepositoryId": "c38bdb18-40c4-4835-b2f8-44df3ebb2d3d",
                 "name": "halkeye",
                 "displayName": null
             }
@@ -60,7 +56,6 @@
             "logoImageId": "2fbaacae-e538-4706-a9fc-bcf443218af1",
             "appVersion": "1.0",
             "chartRepository": {
-                "chartRepositoryId": "77cd4586-0551-4e80-be64-cddca21c2d3b",
                 "name": "billimek",
                 "displayName": null
             }

--- a/web/src/layout/home/__fixtures__/packagesUpdates/5.json
+++ b/web/src/layout/home/__fixtures__/packagesUpdates/5.json
@@ -9,7 +9,6 @@
             "logoImageId": "b8a744f8-5bdc-4b2c-9bc7-295fe0d6b449",
             "appVersion": "lts",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -22,7 +21,6 @@
             "logoImageId": "af1bf4f3-e422-4de5-a023-ca5ad911e228",
             "appVersion": "1.10.4",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -35,7 +33,6 @@
             "logoImageId": null,
             "appVersion": "0.27.5",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -48,7 +45,6 @@
             "logoImageId": null,
             "appVersion": "1.14.6",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }
@@ -61,7 +57,6 @@
             "logoImageId": "61c68f47-1ec8-42fe-a108-959644f148b0",
             "appVersion": "1.3.3.22",
             "chartRepository": {
-                "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                 "name": "stable",
                 "displayName": null
             }

--- a/web/src/layout/package/__fixtures__/details/1.json
+++ b/web/src/layout/package/__fixtures__/details/1.json
@@ -42,7 +42,6 @@
   "digest": "4213f8b0a86bcd063a253ec2395586ec1ff932594ced221ce25a1e75d681ccd2",
   "maintainers": null,
   "chartRepository": {
-    "chartRepositoryId": "dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
     "name": "incubator",
     "displayName": null,
     "url": "https://kubernetes-charts-incubator.storage.googleapis.com"

--- a/web/src/layout/package/__fixtures__/index/1.json
+++ b/web/src/layout/package/__fixtures__/index/1.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/2.json
+++ b/web/src/layout/package/__fixtures__/index/2.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/3.json
+++ b/web/src/layout/package/__fixtures__/index/3.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/4.json
+++ b/web/src/layout/package/__fixtures__/index/4.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/5.json
+++ b/web/src/layout/package/__fixtures__/index/5.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":"test",
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/6.json
+++ b/web/src/layout/package/__fixtures__/index/6.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/7.json
+++ b/web/src/layout/package/__fixtures__/index/7.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/__fixtures__/index/8.json
+++ b/web/src/layout/package/__fixtures__/index/8.json
@@ -8,7 +8,6 @@
   "appVersion":"1.0.0",
   "readme": "readme",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/package/index.test.tsx
+++ b/web/src/layout/package/index.test.tsx
@@ -25,7 +25,8 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const defaultProps = {
-  packageId: 'id',
+  repoName: 'repoName',
+  packageName: 'packageName',
   searchUrlReferer: null,
 };
 
@@ -136,7 +137,7 @@ describe('Package index', () => {
       expect(link).toBeInTheDocument();
       fireEvent.click(link);
       expect(location.pathname).toBe('/search');
-      expect(location.search).toBe(`?page=1&repo=${mockPackage.chartRepository?.chartRepositoryId}`);
+      expect(location.search).toBe(`?page=1&repo=${mockPackage.chartRepository?.name}`);
 
       await wait();
     });

--- a/web/src/layout/package/index.tsx
+++ b/web/src/layout/package/index.tsx
@@ -142,7 +142,7 @@ const PackageView = (props: Props) => {
                               search: prepareQueryString({
                                 pageNumber: 1,
                                 filters: {
-                                  repo: [detail.chartRepository!.chartRepositoryId!],
+                                  repo: [detail.chartRepository!.name],
                                 },
                               }),
                             }}

--- a/web/src/layout/search/PackageCard.test.tsx
+++ b/web/src/layout/search/PackageCard.test.tsx
@@ -114,7 +114,7 @@ describe('PackageCard', () => {
         search: prepareQuerystring({
           pageNumber: 1,
           filters: {
-            repo: [mockPackage.chartRepository!.chartRepositoryId!]
+            repo: [mockPackage.chartRepository!.name]
           },
         }),
         state: { fromSearchCard: true },

--- a/web/src/layout/search/PackageCard.tsx
+++ b/web/src/layout/search/PackageCard.tsx
@@ -63,7 +63,7 @@ const PackageCard = (props: Props) => {
                                       search: prepareQueryString({
                                         pageNumber: 1,
                                         filters: {
-                                          'repo': [props.package.chartRepository!.chartRepositoryId!],
+                                          'repo': [props.package.chartRepository!.name],
                                         },
                                       }),
                                       state: { fromSearchCard: true },

--- a/web/src/layout/search/__fixtures__/index/1.json
+++ b/web/src/layout/search/__fixtures__/index/1.json
@@ -10,7 +10,6 @@
             "logoImageId": "cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion": "2.1.0",
             "chartRepository": {
-               "chartRepositoryId": "43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name": "stable",
                "displayName": null,
                "url": "url"
@@ -25,7 +24,6 @@
             "logoImageId": null,
             "appVersion": "5.0.1",
             "chartRepository": {
-               "chartRepositoryId": "dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name": "incubator",
                "displayName": null,
                "url": "url"

--- a/web/src/layout/search/__fixtures__/index/10.json
+++ b/web/src/layout/search/__fixtures__/index/10.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/11.json
+++ b/web/src/layout/search/__fixtures__/index/11.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/12.json
+++ b/web/src/layout/search/__fixtures__/index/12.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/13.json
+++ b/web/src/layout/search/__fixtures__/index/13.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url": "url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url": "url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url": "url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url": "url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url": "url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url": "url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url": "url"

--- a/web/src/layout/search/__fixtures__/index/14.json
+++ b/web/src/layout/search/__fixtures__/index/14.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/2.json
+++ b/web/src/layout/search/__fixtures__/index/2.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/3.json
+++ b/web/src/layout/search/__fixtures__/index/3.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/4.json
+++ b/web/src/layout/search/__fixtures__/index/4.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/5.json
+++ b/web/src/layout/search/__fixtures__/index/5.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/8.json
+++ b/web/src/layout/search/__fixtures__/index/8.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/index/9.json
+++ b/web/src/layout/search/__fixtures__/index/9.json
@@ -10,7 +10,6 @@
             "logoImageId":"cc7ac35f-abd3-4594-a375-aebfccbfe11e",
             "appVersion":"2.1.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -25,7 +24,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"
@@ -40,7 +38,6 @@
             "logoImageId":"c4b74ab7-dfcd-440c-9ffb-7b9187ea13e2",
             "appVersion":"v0.9.4",
             "chartRepository":{
-               "chartRepositoryId":"b021c8c0-b0dc-45d4-b106-48798142b505",
                "name":"dhiatn",
                "displayName":null,
                "url":"url"
@@ -55,7 +52,6 @@
             "logoImageId":"9d48cd3f-d6f0-499e-b070-4dd30def1306",
             "appVersion":"2.1.4",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -70,7 +66,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.2",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -85,7 +80,6 @@
             "logoImageId":"2af77252-fa22-4b56-97c2-2e0da1307601",
             "appVersion":"3.8.0",
             "chartRepository":{
-               "chartRepositoryId":"43898497-a9d0-41eb-9dc7-5c4de0cd0433",
                "name":"stable",
                "displayName":null,
                "url":"url"
@@ -100,7 +94,6 @@
             "logoImageId":null,
             "appVersion":"5.0.1",
             "chartRepository":{
-               "chartRepositoryId":"dd9337b4-300c-4b40-b4d4-78f47ede6fcf",
                "name":"incubator",
                "displayName":null,
                "url":"url"

--- a/web/src/layout/search/__fixtures__/packageCard/1.json
+++ b/web/src/layout/search/__fixtures__/packageCard/1.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/2.json
+++ b/web/src/layout/search/__fixtures__/packageCard/2.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/3.json
+++ b/web/src/layout/search/__fixtures__/packageCard/3.json
@@ -7,7 +7,6 @@
   "logoImageId":null,
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/4.json
+++ b/web/src/layout/search/__fixtures__/packageCard/4.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/5.json
+++ b/web/src/layout/search/__fixtures__/packageCard/5.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/6.json
+++ b/web/src/layout/search/__fixtures__/packageCard/6.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/__fixtures__/packageCard/8.json
+++ b/web/src/layout/search/__fixtures__/packageCard/8.json
@@ -7,7 +7,6 @@
   "logoImageId":"imageId",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/layout/search/index.tsx
+++ b/web/src/layout/search/index.tsx
@@ -61,7 +61,6 @@ const SearchView = (props: Props) => {
   useScrollRestorationFix();
 
   const saveScrollPosition = () => {
-    console.log('call');
     setScrollPosition(window.scrollY);
   };
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -7,7 +7,6 @@ export interface ChartRepository {
   name: string;
   displayName: string | null;
   url: string;
-  chartRepositoryId?: string;
 }
 
 export interface Maintainer {

--- a/web/src/utils/__fixtures__/buildPackageURL/2.json
+++ b/web/src/utils/__fixtures__/buildPackageURL/2.json
@@ -7,7 +7,6 @@
   "logoImageId":null,
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"

--- a/web/src/utils/__fixtures__/buildPackageURL/3.json
+++ b/web/src/utils/__fixtures__/buildPackageURL/3.json
@@ -8,7 +8,6 @@
   "version":"1.0.0",
   "appVersion":"1.0.0",
   "chartRepository":{
-    "chartRepositoryId":"repoId",
     "name":"stable",
     "displayName":null,
     "url": "repoUrl"


### PR DESCRIPTION
Chart repo name is use now instead for consistency with changes introduced in #144.

Related to #139

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>