### PR TITLE
Do not enforce digest uniqueness across packages

### DIFF
--- a/database/migrations/schema/001_initial_schema.sql
+++ b/database/migrations/schema/001_initial_schema.sql
@@ -106,14 +106,15 @@ create table if not exists snapshot (
     keywords text[],
     home_url text check (home_url <> ''),
     app_version text check (app_version <> ''),
-    digest text check (digest <> '') unique,
+    digest text check (digest <> ''),
     readme text check (readme <> ''),
     links jsonb,
     data jsonb,
     deprecated boolean,
     created_at timestamptz default current_timestamp not null,
     updated_at timestamptz default current_timestamp not null,
-    primary key (package_id, version)
+    primary key (package_id, version),
+    unique (package_id, digest)
 );
 
 create table if not exists maintainer (

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -218,7 +218,7 @@ select indexes_are('session', array[
 ]);
 select indexes_are('snapshot', array[
     'snapshot_pkey',
-    'snapshot_digest_key'
+    'snapshot_package_id_digest_key'
 ]);
 select indexes_are('subscription', array[
     'subscription_pkey'


### PR DESCRIPTION
Digest must be unique only within a package. This means each version of a given package is supposed to have a different digest, but the same digest could appear in other packages' versions.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>