### PR TITLE
Add repositories kinds filter to tracker

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -98,7 +98,8 @@ The following table lists the configurable parameters of the Artifact Hub chart 
 | `tracker.cronjob.image.repository`     | Tracker image repository          | `artifacthub/tracker`                      |
 | `tracker.cronjob.resources`            | Tracker requested resources       | Memory: `500Mi`, CPU: `100m`               |
 | `tracker.concurrency`                  | Repos to process concurrently     | 10                                         |
-| `tracker.repositories`                 | Repos names to process ([] = all) | []                                         |
+| `tracker.repositoriesNames`            | Repos names to process ([] = all) | []                                         |
+| `tracker.repositoriesKinds`            | Repos kinds to process ([] = all) | []                                         |
 | `tracker.imageStore`                   | Image store                       | `pg`                                       |
 | `tracker.bypassDigestCheck`            | Bypass digest check               | `false`                                    |
 

--- a/chart/templates/tracker_secret.yaml
+++ b/chart/templates/tracker_secret.yaml
@@ -16,6 +16,7 @@ stringData:
       password: {{ .Values.db.password }}
     tracker:
       concurrency: {{ .Values.tracker.concurrency }}
-      repositoriesNames: {{ .Values.tracker.repositories }}
+      repositoriesNames: {{ .Values.tracker.repositoriesNames }}
+      repositoriesKinds: {{ .Values.tracker.repositoriesKinds }}
       imageStore: {{ .Values.tracker.imageStore }}
       bypassDigestCheck: {{ .Values.tracker.bypassDigestCheck }}

--- a/chart/values-production.yaml
+++ b/chart/values-production.yaml
@@ -54,5 +54,6 @@ tracker:
         cpu: 2
         memory: 4000Mi
   concurrency: 25
-  repositories: []
+  repositoriesNames: []
+  repositoriesKinds: []
   imageStore: pg

--- a/chart/values-staging.yaml
+++ b/chart/values-staging.yaml
@@ -54,5 +54,6 @@ tracker:
         cpu: 2
         memory: 2000Mi
   concurrency: 10
-  repositories: []
+  repositoriesNames: []
+  repositoriesKinds: []
   imageStore: pg

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -86,7 +86,8 @@ tracker:
         cpu: 100m
         memory: 500Mi
   concurrency: 10
-  repositories: []
+  repositoriesNames: []
+  repositoriesKinds: []
   imageStore: pg
   bypassDigestCheck: false
 

--- a/configs/tracker.yaml
+++ b/configs/tracker.yaml
@@ -10,5 +10,6 @@ db:
 tracker:
   concurrency: 10
   repositoriesNames: []
+  repositoriesKinds: []
   imageStore: pg
   bypassDigestCheck: false

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -40,6 +40,7 @@
 {{ template "repositories/add_repository.sql" }}
 {{ template "repositories/delete_repository.sql" }}
 {{ template "repositories/get_all_repositories.sql" }}
+{{ template "repositories/get_repositories_by_kind.sql" }}
 {{ template "repositories/get_repository_by_name.sql" }}
 {{ template "repositories/get_repository_packages_digest.sql" }}
 {{ template "repositories/get_org_repositories.sql" }}

--- a/database/migrations/functions/repositories/get_repositories_by_kind.sql
+++ b/database/migrations/functions/repositories/get_repositories_by_kind.sql
@@ -1,0 +1,14 @@
+-- get_repositories_by_kind returns all available repositories of a given kind
+-- as a json array.
+create or replace function get_repositories_by_kind(p_kind int)
+returns setof json as $$
+    select coalesce(json_agg(json_build_object(
+        'repository_id', repository_id,
+        'name', name,
+        'display_name', display_name,
+        'url', url,
+        'kind', repository_kind_id
+    )), '[]')
+    from repository
+    where repository_kind_id = p_kind;
+$$ language sql;

--- a/database/tests/functions/repositories/get_repositories_by_kind.sql
+++ b/database/tests/functions/repositories/get_repositories_by_kind.sql
@@ -1,0 +1,61 @@
+-- Start transaction and plan tests
+begin;
+select plan(3);
+
+-- Declare some variables
+\set user1ID '00000000-0000-0000-0000-000000000001'
+\set repo1ID '00000000-0000-0000-0000-000000000001'
+\set repo2ID '00000000-0000-0000-0000-000000000002'
+\set repo3ID '00000000-0000-0000-0000-000000000003'
+
+
+-- No repositories at this point
+select is(
+    get_repositories_by_kind(0)::jsonb,
+    '[]'::jsonb,
+    'With no repositories an empty json array is returned'
+);
+
+-- Seed some data
+insert into "user" (user_id, alias, email)
+values (:'user1ID', 'user1', 'user1@email.com');
+insert into repository (repository_id, name, display_name, url, repository_kind_id, user_id)
+values (:'repo1ID', 'repo1', 'Repo 1', 'https://repo1.com', 0, :'user1ID');
+insert into repository (repository_id, name, display_name, url, repository_kind_id, user_id)
+values (:'repo2ID', 'repo2', 'Repo 2', 'https://repo2.com', 0, :'user1ID');
+insert into repository (repository_id, name, display_name, url, repository_kind_id, user_id)
+values (:'repo3ID', 'repo3', 'Repo 3', 'https://repo3.com', 1, :'user1ID');
+
+-- Run some tests
+select is(
+    get_repositories_by_kind(0)::jsonb,
+    '[{
+        "repository_id": "00000000-0000-0000-0000-000000000001",
+        "name": "repo1",
+        "display_name": "Repo 1",
+        "url": "https://repo1.com",
+        "kind": 0
+    }, {
+        "repository_id": "00000000-0000-0000-0000-000000000002",
+        "name": "repo2",
+        "display_name": "Repo 2",
+        "url": "https://repo2.com",
+        "kind": 0
+    }]'::jsonb,
+    'Repositories 1 and 2 are returned'
+);
+select is(
+    get_repositories_by_kind(1)::jsonb,
+    '[{
+        "repository_id": "00000000-0000-0000-0000-000000000003",
+        "name": "repo3",
+        "display_name": "Repo 3",
+        "url": "https://repo3.com",
+        "kind": 1
+    }]'::jsonb,
+    'Repository 3 is returned'
+);
+
+-- Finish tests and rollback transaction
+select * from finish();
+rollback;

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -1,6 +1,6 @@
 -- Start transaction and plan tests
 begin;
-select plan(111);
+select plan(112);
 
 -- Check default_text_search_config is correct
 select results_eq(
@@ -346,6 +346,7 @@ select has_function('unregister_package');
 select has_function('add_repository');
 select has_function('delete_repository');
 select has_function('get_all_repositories');
+select has_function('get_repositories_by_kind');
 select has_function('get_repository_by_name');
 select has_function('get_repository_packages_digest');
 select has_function('get_org_repositories');

--- a/internal/hub/repo.go
+++ b/internal/hub/repo.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 
 	helmrepo "helm.sh/helm/v3/pkg/repo"
 )
@@ -39,6 +40,23 @@ func GetKindName(kind RepositoryKind) string {
 	}
 }
 
+// GetKindFromName returns the kind of the provided repository from the name
+// provided.
+func GetKindFromName(kind string) (RepositoryKind, error) {
+	switch kind {
+	case "helm":
+		return Helm, nil
+	case "falco":
+		return Falco, nil
+	case "olm":
+		return OLM, nil
+	case "opa":
+		return OPA, nil
+	default:
+		return -1, errors.New("invalid kind name")
+	}
+}
+
 // Repository represents a packages repository.
 type Repository struct {
 	RepositoryID            string         `json:"repository_id"`
@@ -60,6 +78,7 @@ type RepositoryManager interface {
 	CheckAvailability(ctx context.Context, resourceKind, value string) (bool, error)
 	Delete(ctx context.Context, name string) error
 	GetAll(ctx context.Context) ([]*Repository, error)
+	GetByKind(ctx context.Context, kind RepositoryKind) ([]*Repository, error)
 	GetByName(ctx context.Context, name string) (*Repository, error)
 	GetPackagesDigest(ctx context.Context, repositoryID string) (map[string]string, error)
 	GetOwnedByOrgJSON(ctx context.Context, orgName string) ([]byte, error)

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -147,6 +147,13 @@ func (m *Manager) GetAll(ctx context.Context) ([]*hub.Repository, error) {
 	return r, err
 }
 
+// GetByKind returns all available repositories of the provided kind.
+func (m *Manager) GetByKind(ctx context.Context, kind hub.RepositoryKind) ([]*hub.Repository, error) {
+	var r []*hub.Repository
+	err := m.dbQueryUnmarshal(ctx, &r, "select get_repositories_by_kind($1::int)", kind)
+	return r, err
+}
+
 // GetByName returns the repository identified by the name provided.
 func (m *Manager) GetByName(ctx context.Context, name string) (*hub.Repository, error) {
 	// Validate input

--- a/internal/repo/manager_test.go
+++ b/internal/repo/manager_test.go
@@ -405,6 +405,44 @@ func TestGetAll(t *testing.T) {
 	db.AssertExpectations(t)
 }
 
+func TestGetByKind(t *testing.T) {
+	dbQuery := "select get_repositories_by_kind($1::int)"
+	ctx := context.Background()
+
+	db := &tests.DBMock{}
+	db.On("QueryRow", ctx, dbQuery, hub.Helm).Return([]byte(`
+	[{
+        "repository_id": "00000000-0000-0000-0000-000000000001",
+        "name": "repo1",
+        "display_name": "Repo 1",
+		"url": "https://repo1.com",
+		"kind": 0
+    }, {
+        "repository_id": "00000000-0000-0000-0000-000000000002",
+        "name": "repo2",
+        "display_name": "Repo 2",
+		"url": "https://repo2.com",
+		"kind": 0
+    }]
+	`), nil)
+	m := NewManager(db)
+
+	r, err := m.GetByKind(ctx, hub.Helm)
+	require.NoError(t, err)
+	assert.Len(t, r, 2)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", r[0].RepositoryID)
+	assert.Equal(t, "repo1", r[0].Name)
+	assert.Equal(t, "Repo 1", r[0].DisplayName)
+	assert.Equal(t, "https://repo1.com", r[0].URL)
+	assert.Equal(t, hub.Helm, r[0].Kind)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000002", r[1].RepositoryID)
+	assert.Equal(t, "repo2", r[1].Name)
+	assert.Equal(t, "Repo 2", r[1].DisplayName)
+	assert.Equal(t, "https://repo2.com", r[1].URL)
+	assert.Equal(t, hub.Helm, r[1].Kind)
+	db.AssertExpectations(t)
+}
+
 func TestGetByName(t *testing.T) {
 	dbQuery := "select get_repository_by_name($1::text)"
 	ctx := context.Background()

--- a/internal/repo/mock.go
+++ b/internal/repo/mock.go
@@ -38,6 +38,13 @@ func (m *ManagerMock) GetAll(ctx context.Context) ([]*hub.Repository, error) {
 	return data, args.Error(1)
 }
 
+// GetByKind implements the RepositoryManager interface.
+func (m *ManagerMock) GetByKind(ctx context.Context, kind hub.RepositoryKind) ([]*hub.Repository, error) {
+	args := m.Called(ctx, kind)
+	data, _ := args.Get(0).([]*hub.Repository)
+	return data, args.Error(1)
+}
+
 // GetByName implements the RepositoryManager interface.
 func (m *ManagerMock) GetByName(ctx context.Context, name string) (*hub.Repository, error) {
 	args := m.Called(ctx, name)


### PR DESCRIPTION
In addition to ask the tracker to only process some repositories by providing their name, it's now also possible to only process the repositories of the kinds provided.

This is handy when, for any reason, it's necessary to reindex all packages from repositories of a given kind (usually used in combination with the `bypassDigest` flag).

Closes #573

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>