### PR TITLE
fix: change default PostgreSQL hostname

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.6.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/ci/ct-values.yaml
+++ b/charts/artifact-hub/ci/ct-values.yaml
@@ -1,3 +1,1 @@
 fullnameOverride: hub
-postgresql:
-  fullnameOverride: hub-postgresql

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: PGHOST
-            value: {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+            value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
           - name: PGPORT
             value: "{{ .Values.db.port }}"
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']

--- a/charts/artifact-hub/templates/db_migrator_secret.yaml
+++ b/charts/artifact-hub/templates/db_migrator_secret.yaml
@@ -7,7 +7,7 @@ type: Opaque
 stringData:
   tern.conf: |-
     [database]
-    host = {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+    host = {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
     port = {{ .Values.db.port }}
     database = {{ .Values.db.database }}
     user = {{ .Values.db.user }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -32,7 +32,7 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: PGHOST
-            value: {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+            value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
           - name: PGPORT
             value: "{{ .Values.db.port }}"
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']

--- a/charts/artifact-hub/templates/hub_secret.yaml
+++ b/charts/artifact-hub/templates/hub_secret.yaml
@@ -10,7 +10,7 @@ stringData:
       level: {{ .Values.log.level }}
       pretty: {{ .Values.log.pretty }}
     db:
-      host: {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+      host: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
       port: {{ .Values.db.port }}
       database: {{ .Values.db.database }}
       user: {{ .Values.db.user }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -24,7 +24,7 @@ spec:
               {{- toYaml .Values.tracker.cronjob.resources | nindent 14 }}
             env:
               - name: PGHOST
-                value: {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+                value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
               - name: PGPORT
                 value: "{{ .Values.db.port }}"
             command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']

--- a/charts/artifact-hub/templates/tracker_secret.yaml
+++ b/charts/artifact-hub/templates/tracker_secret.yaml
@@ -10,7 +10,7 @@ stringData:
       level: {{ .Values.log.level }}
       pretty: {{ .Values.log.pretty }}
     db:
-      host: {{ default (printf "%s-postgresql.%s" $fullName .Release.Namespace) .Values.db.host }}
+      host: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
       port: {{ .Values.db.port }}
       database: {{ .Values.db.database }}
       user: {{ .Values.db.user }}


### PR DESCRIPTION
The default DB hostname with $fullName would be
"hub-artifact-hub-postgresql" or similar, but the actual Service name
is "hub-postgres", derived from the release name and postgres' chart
name (see
https://github.com/helm/charts/blob/817ac3692e30d933610fdcbef805120eec1da582/stable/postgresql/templates/svc.yaml#L4
and
https://github.com/helm/charts/blob/817ac3692e30d933610fdcbef805120eec1da582/stable/postgresql/templates/_helpers.tpl#L13-L24
for evidence).

Signed-off-by: Max Jonas Werner <mail@makk.es>