### PR TITLE
Allow repo metadata files to use either .yaml or .yml

### DIFF
--- a/internal/hub/repo.go
+++ b/internal/hub/repo.go
@@ -10,7 +10,7 @@ import (
 const (
 	// RepositoryMetadataFile represents the name of the file where the
 	// Artifact Hub metadata for a given repository is stored.
-	RepositoryMetadataFile = "artifacthub-repo.yml"
+	RepositoryMetadataFile = "artifacthub-repo"
 )
 
 // RepositoryKind represents the kind of a given repository.

--- a/internal/repo/testdata/test-yaml-repo.yaml
+++ b/internal/repo/testdata/test-yaml-repo.yaml
@@ -1,0 +1,4 @@
+repositoryID: 00000000-0000-0000-0000-000000000001
+owners:
+  - name: owner1
+    email: owner1@email.com


### PR DESCRIPTION
Allows using either the `.yml` or `.yaml` extensions for repo metadata files. This solution does require an extra request, but couldn't think of another way to do it without larger refactors. Happy to make any changes! 