### PR TITLE
Bump to Go 1.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.swp
 .vscode
+.idea
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artifacthub/hub
 
-go 1.13
+go 1.15
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect


### PR DESCRIPTION
The builder docker file: https://github.com/artifacthub/hub/blob/master/cmd/hub/Dockerfile uses go 1.15
Switching to 1.15 for go.mod (and ignore goland file)

Signed-off-by: Ken Sipe <kensipe@gmail.com>