### PR TITLE
Improve repository url uniqueness check

### DIFF
--- a/database/migrations/schema/001_initial_schema.sql
+++ b/database/migrations/schema/001_initial_schema.sql
@@ -83,7 +83,7 @@ create table if not exists repository (
     repository_id uuid primary key default gen_random_uuid(),
     name text not null check (name <> '') unique,
     display_name text check (display_name <> ''),
-    url text not null check (url <> '') unique,
+    url text not null check (url <> ''),
     auth_user text check (auth_user <> ''),
     auth_pass text check (auth_pass <> ''),
     last_tracking_ts timestamptz,
@@ -102,6 +102,7 @@ create table if not exists repository (
 create index repository_repository_kind_id_idx on repository (repository_kind_id);
 create index repository_user_id_idx on repository (user_id);
 create index repository_organization_id_idx on repository (organization_id);
+create unique index repository_url_idx on repository (trim(trailing '/' from url));
 
 create table if not exists package (
     package_id uuid primary key default gen_random_uuid(),

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -294,7 +294,7 @@ select indexes_are('package__maintainer', array[
 select indexes_are('repository', array[
     'repository_pkey',
     'repository_name_key',
-    'repository_url_key',
+    'repository_url_idx',
     'repository_repository_kind_id_idx',
     'repository_user_id_idx',
     'repository_organization_id_idx'

--- a/internal/repo/manager.go
+++ b/internal/repo/manager.go
@@ -32,7 +32,7 @@ const (
 	// Database queries
 	addRepoDBQ                = `select add_repository($1::uuid, $2::text, $3::jsonb)`
 	checkRepoNameAvailDBQ     = `select repository_id from repository where name = $1`
-	checkRepoURLAvailDBQ      = `select repository_id from repository where url = $1`
+	checkRepoURLAvailDBQ      = `select repository_id from repository where trim(trailing '/' from url) = $1`
 	deleteRepoDBQ             = `select delete_repository($1::uuid, $2::text)`
 	getAllReposDBQ            = `select get_all_repositories($1::boolean)`
 	getOrgReposDBQ            = `select get_org_repositories($1::uuid, $2::text, $3::boolean)`
@@ -201,6 +201,7 @@ func (m *Manager) CheckAvailability(ctx context.Context, resourceKind, value str
 		query = checkRepoURLAvailDBQ
 	}
 	query = fmt.Sprintf("select not exists (%s)", query)
+	value = strings.TrimSuffix(value, "/")
 	err := m.db.QueryRow(ctx, query, value).Scan(&available)
 	return available, err
 }

--- a/internal/repo/manager_test.go
+++ b/internal/repo/manager_test.go
@@ -367,7 +367,7 @@ func TestCheckAvailability(t *testing.T) {
 				db.On("QueryRow", ctx, tc.dbQuery, "value").Return(tc.available, nil)
 				m := NewManager(cfg, db, nil)
 
-				available, err := m.CheckAvailability(ctx, tc.resourceKind, "value")
+				available, err := m.CheckAvailability(ctx, tc.resourceKind, "value/")
 				assert.NoError(t, err)
 				assert.Equal(t, tc.available, available)
 				db.AssertExpectations(t)


### PR DESCRIPTION
A repository url with or without a trailing slash is now considered the same.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>