### PR TITLE
update dev instructions to also set a port for metricsAddr

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -101,6 +101,7 @@ db:
   user: postgres
 server:
   addr: localhost:8000
+  metricsAddr: localhost:8001
   shutdownTimeout: 10s
   webBuildPath: ../../web/build
   basicAuth:


### PR DESCRIPTION
without that the hub service requires root permissions to run
as metricsAddr defaults to bind to port 80.

Signed-off-by: Dirk Mueller <dirk@dmllr.de>