### PR TITLE
Swap colors of the star/unstar icon

### DIFF
--- a/web/src/layout/package/StarButton.tsx
+++ b/web/src/layout/package/StarButton.tsx
@@ -100,7 +100,7 @@ const StarButton = (props: Props) => {
           onClick={handleToggleStar}
         >
           <div className="d-flex align-items-center">
-            {notStarred ? <FaStar /> : <FaRegStar />}
+            {notStarred ? <FaRegStar /> : <FaStar />}
             <span className="ml-2">{notStarred ? 'Star' : 'Unstar'}</span>
           </div>
         </button>


### PR DESCRIPTION
This PR swaps FontAwesome icons of the Star/Unstar button.

There are four places using the star FontAwesome icons but only one type of star icon (FaStar) is used there. So we need to fix only this usage.

Fixes #948.