### PR TITLE
Allow disabling different OAuth settings

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 0.13.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/templates/hub_secret.yaml
+++ b/charts/artifact-hub/templates/hub_secret.yaml
@@ -30,16 +30,28 @@ stringData:
         hashKey: {{ .Values.hub.server.cookie.hashKey }}
         secure: {{ .Values.hub.server.cookie.secure }}
       oauth:
+        {{- if .Values.hub.server.oauth.github.enabled }}
         github:
           clientID: {{ .Values.hub.server.oauth.github.clientID }}
           clientSecret: {{ .Values.hub.server.oauth.github.clientSecret }}
           redirectURL: {{ .Values.hub.server.oauth.github.redirectURL }}
           scopes: {{ .Values.hub.server.oauth.github.scopes }}
+        {{- end }}
+        {{- if .Values.hub.server.oauth.google.enabled }}
         google:
           clientID: {{ .Values.hub.server.oauth.google.clientID }}
           clientSecret: {{ .Values.hub.server.oauth.google.clientSecret }}
           redirectURL: {{ .Values.hub.server.oauth.google.redirectURL }}
           scopes: {{ .Values.hub.server.oauth.google.scopes }}
+        {{- end }}
+        {{- if .Values.hub.server.oauth.oidc.enabled }}
+        oidc:
+          clientID: {{ .Values.hub.server.oauth.oidc.clientID }}
+          issuerURL: {{ .Values.hub.server.oauth.oidc.issuerURL }}
+          clientSecret: {{ .Values.hub.server.oauth.oidc.clientSecret }}
+          redirectURL: {{ .Values.hub.server.oauth.oidc.redirectURL }}
+          scopes: {{ .Values.hub.server.oauth.oidc.scopes }}
+        {{- end }}
       xffIndex: {{ .Values.hub.server.xffIndex }}
     email:
       fromName: {{ .Values.hub.email.fromName }}

--- a/charts/artifact-hub/values-production.yaml
+++ b/charts/artifact-hub/values-production.yaml
@@ -45,8 +45,10 @@ hub:
     shutdownTimeout: 20s
     oauth:
       github:
+        enabled: true
         redirectURL: https://artifacthub.io/oauth/github/callback
       google:
+        enabled: true
         redirectURL: https://artifacthub.io/oauth/google/callback
 
 scanner:

--- a/charts/artifact-hub/values-staging.yaml
+++ b/charts/artifact-hub/values-staging.yaml
@@ -37,8 +37,10 @@ hub:
     shutdownTimeout: 20s
     oauth:
       github:
+        enabled: true
         redirectURL: https://staging.artifacthub.io/oauth/github/callback
       google:
+        enabled: true
         redirectURL: https://staging.artifacthub.io/oauth/google/callback
 
 scanner:

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -264,6 +264,11 @@
                                 "github": {
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "title": "Enable Github oauth",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
                                         "clientID": {
                                             "title": "Github oauth client id",
                                             "type": "string",
@@ -296,6 +301,11 @@
                                 "google": {
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "title": "Enable Google oauth",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
                                         "clientID": {
                                             "title": "Google oauth client id",
                                             "type": "string",
@@ -328,6 +338,11 @@
                                 "oidc": {
                                     "type": "object",
                                     "properties": {
+                                        "enabled": {
+                                            "title": "Enable OIDC",
+                                            "type": "boolean",
+                                            "default": false
+                                        },
                                         "issuerURL": {
                                             "title": "OpenID connect issuer url",
                                             "type": "string",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -267,7 +267,7 @@
                                         "enabled": {
                                             "title": "Enable Github oauth",
                                             "type": "boolean",
-                                            "default": true
+                                            "default": false
                                         },
                                         "clientID": {
                                             "title": "Github oauth client id",
@@ -304,7 +304,7 @@
                                         "enabled": {
                                             "title": "Enable Google oauth",
                                             "type": "boolean",
-                                            "default": true
+                                            "default": false
                                         },
                                         "clientID": {
                                             "title": "Google oauth client id",

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -50,7 +50,7 @@ hub:
       secure: false
     oauth:
       github:
-        enabled: true
+        enabled: false
         clientID: ""
         clientSecret: ""
         redirectURL: ""
@@ -58,7 +58,7 @@ hub:
           - read:user
           - user:email
       google:
-        enabled: true
+        enabled: false
         clientID: ""
         clientSecret: ""
         redirectURL: ""

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -50,6 +50,7 @@ hub:
       secure: false
     oauth:
       github:
+        enabled: true
         clientID: ""
         clientSecret: ""
         redirectURL: ""
@@ -57,12 +58,23 @@ hub:
           - read:user
           - user:email
       google:
+        enabled: true
         clientID: ""
         clientSecret: ""
         redirectURL: ""
         scopes:
           - https://www.googleapis.com/auth/userinfo.email
           - https://www.googleapis.com/auth/userinfo.profile
+      oidc:
+        enabled: false
+        issuerURL: ""
+        clientID: ""
+        clientSecret: ""
+        redirectURL: ""
+        scopes:
+          - openid
+          - profile
+          - email
     xffIndex: 0
   email:
     fromName: ""


### PR DESCRIPTION
Hi everyone!
In my self-hosted environment I currently don't want to enable the OAuth login mechanisms.
These mechanisms are enabled as soon as the section is available in the config.

This PR modifies the Helm chart in the following way:
- Add OIDC section to `values.yaml`
- Add OIDC section in `hub_secret.yaml` template
- Add `enabled` value to each OAuth section which determines if the
  section is added to the secret / config

The default behavior should not be touched. GitHub and Google are enabled by default, OIDC is disabled by default.

Tell me if I can change something (but also feel free to edit).
A different approach would be, for example, to add the `enabled` flag to the config and use the value of the flag at runtime - instead of the presence of the section - to determine if the login mechanism should be enabled or not.