### PR TITLE
Fix config & cache handling with random security context

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: 0.13.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -27,10 +27,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /home/db-migrator/.cfg/tern.conf
+            value: /artifacthub/.cfg/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/home/db-migrator/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -30,10 +30,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /home/db-migrator/.cfg/tern.conf
+            value: /artifacthub/.cfg/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/home/db-migrator/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -59,7 +59,7 @@ spec:
           {{- end }}
           volumeMounts:
           - name: hub-config
-            mountPath: "/home/hub/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
           {{- if .Values.hub.server.cacheDir }}
           - name: cache-dir

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -52,10 +52,19 @@ spec:
         - name: hub
           image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- if .Values.hub.server.cacheDir }}
+          env:
+            - name: XDG_CACHE_HOME
+              value: {{ .Values.hub.server.cacheDir | quote }}
+          {{- end }}
           volumeMounts:
           - name: hub-config
             mountPath: "/home/hub/.cfg"
             readOnly: true
+          {{- if .Values.hub.server.cacheDir }}
+          - name: cache-dir
+            mountPath: {{ .Values.hub.server.cacheDir | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8000
@@ -66,3 +75,7 @@ spec:
       - name: hub-config
         secret:
           secretName: hub-config
+      {{- if .Values.hub.server.cacheDir }}
+      - name: cache-dir
+        emptyDir: {}
+      {{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -41,7 +41,7 @@ spec:
             {{- end }}
             volumeMounts:
             - name: scanner-config
-              mountPath: "/home/scanner/.cfg"
+              mountPath: "/artifacthub/.cfg"
               readOnly: true
             {{- if .Values.scanner.cacheDir }}
             - name: cache-dir

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -32,11 +32,26 @@ spec:
           - name: scanner
             image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag }}
             imagePullPolicy: {{ .Values.pullPolicy }}
+            {{- if .Values.scanner.cacheDir }}
+            env:
+              - name: TRIVY_CACHE_DIR
+                value: {{ .Values.scanner.cacheDir | quote }}
+              - name: XDG_CACHE_HOME
+                value: {{ .Values.scanner.cacheDir | quote }}
+            {{- end }}
             volumeMounts:
             - name: scanner-config
               mountPath: "/home/scanner/.cfg"
               readOnly: true
+            {{- if .Values.scanner.cacheDir }}
+            - name: cache-dir
+              mountPath: {{ .Values.scanner.cacheDir | quote }}
+            {{- end }}
           volumes:
           - name: scanner-config
             secret:
               secretName: scanner-config
+          {{- if .Values.scanner.cacheDir }}
+          - name: cache-dir
+            emptyDir: {}
+          {{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -32,11 +32,24 @@ spec:
           - name: tracker
             image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag }}
             imagePullPolicy: {{ .Values.pullPolicy }}
+            {{- if .Values.tracker.cacheDir }}
+            env:
+              - name: XDG_CACHE_HOME
+                value: {{ .Values.tracker.cacheDir | quote }}
+            {{- end }}
             volumeMounts:
             - name: tracker-config
               mountPath: "/home/tracker/.cfg"
               readOnly: true
+            {{- if .Values.tracker.cacheDir }}
+            - name: cache-dir
+              mountPath: {{ .Values.tracker.cacheDir | quote }}
+            {{- end }}
           volumes:
           - name: tracker-config
             secret:
               secretName: tracker-config
+          {{- if .Values.tracker.cacheDir }}
+          - name: cache-dir
+            emptyDir: {}
+          {{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
             volumeMounts:
             - name: tracker-config
-              mountPath: "/home/tracker/.cfg"
+              mountPath: "/artifacthub/.cfg"
               readOnly: true
             {{- if .Values.tracker.cacheDir }}
             - name: cache-dir

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -216,6 +216,11 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "cacheDir": {
+                            "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                            "type": "string",
+                            "default": ""
+                        },
                         "baseURL": {
                             "title": "Hub server base url",
                             "type": "string",
@@ -484,6 +489,11 @@
                     "type": "string",
                     "default": "http://trivy:8081"
                 },
+                "cacheDir": {
+                    "title": "If set, the cache directories for the Trivy and Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "type": "string",
+                    "default": ""
+                },
                 "dockerUsername": {
                     "title": "Docker registry username",
                     "type": "string",
@@ -505,6 +515,11 @@
                     "title": "Bypass digest check",
                     "type": "boolean",
                     "default": false
+                },
+                "cacheDir": {
+                    "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "type": "string",
+                    "default": ""
                 },
                 "concurrency": {
                     "title": "Repositories to process concurrently",

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -39,6 +39,7 @@ hub:
     resources: {}
   server:
     allowPrivateRepositories: false
+    cacheDir: ""
     baseURL: ""
     shutdownTimeout: 10s
     basicAuth:
@@ -95,6 +96,7 @@ scanner:
     resources: {}
   concurrency: 10
   trivyURL: http://trivy:8081
+  cacheDir: ""
   dockerUsername: ""
   dockerPassword: ""
 
@@ -103,6 +105,7 @@ tracker:
     image:
       repository: artifacthub/tracker
     resources: {}
+  cacheDir: ""
   concurrency: 10
   repositoriesNames: []
   repositoriesKinds: []

--- a/internal/scanner/trivy.go
+++ b/internal/scanner/trivy.go
@@ -36,6 +36,7 @@ func (s *TrivyScanner) Scan(image string) ([]byte, error) {
 		"PATH=" + os.Getenv("PATH"),
 		"USER=" + os.Getenv("USER"),
 		"HOME=" + os.Getenv("HOME"),
+		"TRIVY_CACHE_DIR=" + os.Getenv("TRIVY_CACHE_DIR"),
 	}
 
 	// If the registry is the Docker Hub, include credentials to avoid rate

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -16,6 +16,7 @@ func SetupConfig(cmd string) (*viper.Viper, error) {
 	// Config file
 	cfg.SetConfigName(cmd)
 	cfg.AddConfigPath("$HOME/.cfg")
+	cfg.AddConfigPath("/artifacthub/.cfg")
 	if err := cfg.ReadInConfig(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi there!

This PR includes the following changes:
- Introduce a new fallback config directory (`/artifacthub/.cfg`) as discussed in #1037.
- Changes the config mounts to use `/artifacthub/.cfg` instead of `/home/hub/.cfg` (which does not work when `$HOME` isn't set).
- Introduce a new field `cacheDir` in the `values.yaml` to explicitly set a cache directory. This field is then used to set the cache for trivy (in the scanner) and helm (in scanner, tracker, hub) by setting the environment variables `TRIVY_CACHE_DIR` and `XDG_CACHE_HOME` (as mentioned in the [Helm documentation](https://helm.sh/docs/faq/#how-do-i-put-the-helm-client-files-somewhere-other-than-their-defaults)).

Fixes #1037 