### PR TITLE
Fix config & cache with random security context

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -3,7 +3,7 @@ name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
 version: 0.13.3
-appVersion: 0.13.1
+appVersion: 0.13.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png
 keywords:

--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: 0.13.1
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -3,7 +3,7 @@ name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
 version: 0.13.2
-appVersion: 0.13.0
+appVersion: 0.13.1
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png
 keywords:

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -27,10 +27,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /home/db-migrator/.cfg/tern.conf
+            value: /artifacthub/.cfg/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/home/db-migrator/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -27,10 +27,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /artifacthub/.cfg/tern.conf
+            value: {{ .Values.dbMigrator.configDir }}/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/artifacthub/.cfg"
+            mountPath: {{ .Values.dbMigrator.configDir }}
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -30,10 +30,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /home/db-migrator/.cfg/tern.conf
+            value: /artifacthub/.cfg/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/home/db-migrator/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -30,10 +30,10 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF
-            value: /artifacthub/.cfg/tern.conf
+            value: {{ .Values.dbMigrator.configDir }}/tern.conf
         volumeMounts:
           - name: db-migrator-config
-            mountPath: "/artifacthub/.cfg"
+            mountPath: {{ .Values.dbMigrator.configDir }}
             readOnly: true
         command: ["./migrate.sh"]
       volumes:

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -52,10 +52,19 @@ spec:
         - name: hub
           image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- if .Values.hub.server.cacheDir }}
+          env:
+            - name: XDG_CACHE_HOME
+              value: {{ .Values.hub.server.cacheDir | quote }}
+          {{- end }}
           volumeMounts:
           - name: hub-config
-            mountPath: "/home/hub/.cfg"
+            mountPath: "/artifacthub/.cfg"
             readOnly: true
+          {{- if .Values.hub.server.cacheDir }}
+          - name: cache-dir
+            mountPath: {{ .Values.hub.server.cacheDir | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8000
@@ -66,3 +75,7 @@ spec:
       - name: hub-config
         secret:
           secretName: hub-config
+      {{- if .Values.hub.server.cacheDir }}
+      - name: cache-dir
+        emptyDir: {}
+      {{- end }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -59,7 +59,7 @@ spec:
           {{- end }}
           volumeMounts:
           - name: hub-config
-            mountPath: "/artifacthub/.cfg"
+            mountPath: {{ .Values.hub.server.configDir | quote }}
             readOnly: true
           {{- if .Values.hub.server.cacheDir }}
           - name: cache-dir

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
             volumeMounts:
             - name: scanner-config
-              mountPath: "/artifacthub/.cfg"
+              mountPath: {{ .Values.scanner.configDir | quote }}
               readOnly: true
             {{- if .Values.scanner.cacheDir }}
             - name: cache-dir

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -36,8 +36,6 @@ spec:
             env:
               - name: TRIVY_CACHE_DIR
                 value: {{ .Values.scanner.cacheDir | quote }}
-              - name: XDG_CACHE_HOME
-                value: {{ .Values.scanner.cacheDir | quote }}
             {{- end }}
             volumeMounts:
             - name: scanner-config

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -32,11 +32,26 @@ spec:
           - name: scanner
             image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag }}
             imagePullPolicy: {{ .Values.pullPolicy }}
+            {{- if .Values.scanner.cacheDir }}
+            env:
+              - name: TRIVY_CACHE_DIR
+                value: {{ .Values.scanner.cacheDir | quote }}
+              - name: XDG_CACHE_HOME
+                value: {{ .Values.scanner.cacheDir | quote }}
+            {{- end }}
             volumeMounts:
             - name: scanner-config
-              mountPath: "/home/scanner/.cfg"
+              mountPath: "/artifacthub/.cfg"
               readOnly: true
+            {{- if .Values.scanner.cacheDir }}
+            - name: cache-dir
+              mountPath: {{ .Values.scanner.cacheDir | quote }}
+            {{- end }}
           volumes:
           - name: scanner-config
             secret:
               secretName: scanner-config
+          {{- if .Values.scanner.cacheDir }}
+          - name: cache-dir
+            emptyDir: {}
+          {{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -32,11 +32,24 @@ spec:
           - name: tracker
             image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag }}
             imagePullPolicy: {{ .Values.pullPolicy }}
+            {{- if .Values.tracker.cacheDir }}
+            env:
+              - name: XDG_CACHE_HOME
+                value: {{ .Values.tracker.cacheDir | quote }}
+            {{- end }}
             volumeMounts:
             - name: tracker-config
-              mountPath: "/home/tracker/.cfg"
+              mountPath: "/artifacthub/.cfg"
               readOnly: true
+            {{- if .Values.tracker.cacheDir }}
+            - name: cache-dir
+              mountPath: {{ .Values.tracker.cacheDir | quote }}
+            {{- end }}
           volumes:
           - name: tracker-config
             secret:
               secretName: tracker-config
+          {{- if .Values.tracker.cacheDir }}
+          - name: cache-dir
+            emptyDir: {}
+          {{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
             volumeMounts:
             - name: tracker-config
-              mountPath: "/artifacthub/.cfg"
+              mountPath: {{ .Values.tracker.configDir | quote }}
               readOnly: true
             {{- if .Values.tracker.cacheDir }}
             - name: cache-dir

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -216,6 +216,11 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "cacheDir": {
+                            "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                            "type": "string",
+                            "default": ""
+                        },
                         "baseURL": {
                             "title": "Hub server base url",
                             "type": "string",
@@ -484,6 +489,11 @@
                     "type": "string",
                     "default": "http://trivy:8081"
                 },
+                "cacheDir": {
+                    "title": "If set, the cache directories for the Trivy and Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "type": "string",
+                    "default": ""
+                },
                 "dockerUsername": {
                     "title": "Docker registry username",
                     "type": "string",
@@ -505,6 +515,11 @@
                     "title": "Bypass digest check",
                     "type": "boolean",
                     "default": false
+                },
+                "cacheDir": {
+                    "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "type": "string",
+                    "default": ""
                 },
                 "concurrency": {
                     "title": "Repositories to process concurrently",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -60,6 +60,16 @@
                     "title": "Load demo user and sample repositories",
                     "type": "boolean",
                     "default": true
+                },
+                "configDir": {
+                    "title": "Config directory path",
+                    "description": "Directory path where the configuration files should be mounted.",
+                    "type": "string",
+                    "enum": [
+                        "/home/db-migrator/.cfg",
+                        "/artifacthub/.cfg"
+                    ],
+                    "default": "/home/db-migrator/.cfg"
                 }
             },
             "required": ["job", "loadSampleData"]
@@ -221,6 +231,16 @@
                             "description": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
                             "type": "string",
                             "default": ""
+                        },
+                        "configDir": {
+                            "title": "Config directory path",
+                            "description": "Directory path where the configuration files should be mounted.",
+                            "type": "string",
+                            "enum": [
+                                "/home/hub/.cfg",
+                                "/artifacthub/.cfg"
+                            ],
+                            "default": "/home/hub/.cfg"
                         },
                         "baseURL": {
                             "title": "Hub server base url",
@@ -496,6 +516,16 @@
                     "type": "string",
                     "default": ""
                 },
+                "configDir": {
+                    "title": "Config directory path",
+                    "description": "Directory path where the configuration files should be mounted.",
+                    "type": "string",
+                    "enum": [
+                        "/home/scanner/.cfg",
+                        "/artifacthub/.cfg"
+                    ],
+                    "default": "/home/scanner/.cfg"
+                },
                 "dockerUsername": {
                     "title": "Docker registry username",
                     "type": "string",
@@ -523,6 +553,16 @@
                     "description": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
                     "type": "string",
                     "default": ""
+                },
+                "configDir": {
+                    "title": "Config directory path",
+                    "description": "Directory path where the configuration files should be mounted.",
+                    "type": "string",
+                    "enum": [
+                        "/home/tracker/.cfg",
+                        "/artifacthub/.cfg"
+                    ],
+                    "default": "/home/tracker/.cfg"
                 },
                 "concurrency": {
                     "title": "Repositories to process concurrently",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -72,7 +72,7 @@
                     "default": "/home/db-migrator/.cfg"
                 }
             },
-            "required": ["job", "loadSampleData"]
+            "required": ["job", "loadSampleData", "configDir"]
         },
         "fullnameOverride": {
             "type": "string",
@@ -417,7 +417,7 @@
                             "default": 0
                         }
                     },
-                    "required": ["allowPrivateRepositories", "baseURL", "shutdownTimeout", "basicAuth", "cookie", "xffIndex"]
+                    "required": ["allowPrivateRepositories", "configDir", "baseURL", "shutdownTimeout", "basicAuth", "cookie", "xffIndex"]
                 },
                 "service": {
                     "type": "object",
@@ -537,7 +537,7 @@
                     "default": ""
                 }
             },
-            "required": ["concurrency", "cronjob", "trivyURL"]
+            "required": ["concurrency", "cronjob", "trivyURL", "configDir"]
         },
         "tracker": {
             "title": "Tracker configuration",
@@ -634,7 +634,7 @@
                     "uniqueItems": true
                 }
             },
-            "required": ["bypassDigestCheck", "concurrency", "cronjob", "events", "imageStore", "repositoriesKinds", "repositoriesNames"]
+            "required": ["bypassDigestCheck", "configDir", "concurrency", "cronjob", "events", "imageStore", "repositoriesKinds", "repositoriesNames"]
         },
         "trivy": {
             "title": "Trivy configuration",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -217,7 +217,8 @@
                             "default": false
                         },
                         "cacheDir": {
-                            "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                            "title": "Cache directory path",
+                            "description": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
                             "type": "string",
                             "default": ""
                         },
@@ -490,7 +491,8 @@
                     "default": "http://trivy:8081"
                 },
                 "cacheDir": {
-                    "title": "If set, the cache directories for the Trivy and Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "title": "Cache directory path",
+                    "description": "If set, the cache directory for the Trivy client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
                     "type": "string",
                     "default": ""
                 },
@@ -517,7 +519,8 @@
                     "default": false
                 },
                 "cacheDir": {
-                    "title": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
+                    "title": "Cache directory path",
+                    "description": "If set, the cache directory for the Helm client will be explicitly set (otherwise defaults to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir).",
                     "type": "string",
                     "default": ""
                 },

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -20,6 +20,7 @@ dbMigrator:
     image:
       repository: artifacthub/db-migrator
   loadSampleData: true
+  configDir: "/home/db-migrator/.cfg"
 
 hub:
   ingress:
@@ -40,6 +41,7 @@ hub:
   server:
     allowPrivateRepositories: false
     cacheDir: ""
+    configDir: "/home/hub/.cfg"
     baseURL: ""
     shutdownTimeout: 10s
     basicAuth:
@@ -97,6 +99,7 @@ scanner:
   concurrency: 10
   trivyURL: http://trivy:8081
   cacheDir: ""
+  configDir: "/home/scanner/.cfg"
   dockerUsername: ""
   dockerPassword: ""
 
@@ -106,6 +109,7 @@ tracker:
       repository: artifacthub/tracker
     resources: {}
   cacheDir: ""
+  configDir: "/home/tracker/.cfg"
   concurrency: 10
   repositoriesNames: []
   repositoriesKinds: []

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -39,6 +39,7 @@ hub:
     resources: {}
   server:
     allowPrivateRepositories: false
+    cacheDir: ""
     baseURL: ""
     shutdownTimeout: 10s
     basicAuth:
@@ -95,6 +96,7 @@ scanner:
     resources: {}
   concurrency: 10
   trivyURL: http://trivy:8081
+  cacheDir: ""
   dockerUsername: ""
   dockerPassword: ""
 
@@ -103,6 +105,7 @@ tracker:
     image:
       repository: artifacthub/tracker
     resources: {}
+  cacheDir: ""
   concurrency: 10
   repositoriesNames: []
   repositoriesKinds: []


### PR DESCRIPTION
Hi there!

This PR includes the following changes:
- Use the fallback config directory (`/artifacthub/.cfg`).
- Changes the config mounts to use `/artifacthub/.cfg` instead of `/home/hub/.cfg` (which does not work when $HOME isn't set). This has been discussed in #1037 and is introduced in #1043.
- Introduce a new field `cacheDir` in the `values.yaml` to explicitly set a cache directory. This field is then used to set the cache for trivy (in the scanner) and helm (in scanner, tracker, hub) by setting the environment variables `TRIVY_CACHE_DIR` and `XDG_CACHE_HOME` (as mentioned in the Helm documentation). This fix also depends on #1043 to forward the `TRIVY_CACHE_DIR`.

As mentioned above, this PR depends on #1043. Therefore the CI builds won't work for now, but I tested the two PRs together and therefore I wanted to submit both of them now.
Currently it bumps the patch version for both, the Chart version and the appVersion (as I expect the version containing #1043 to be a patch version).

It is the second and final PR. Fixes #1037.