### PR TITLE
Revert "Pass oauth provider enabled flag to index template (#1050)"

### DIFF
--- a/cmd/hub/handlers/static/handlers.go
+++ b/cmd/hub/handlers/static/handlers.go
@@ -150,9 +150,9 @@ func (h *Handlers) ServeIndex(w http.ResponseWriter, r *http.Request) {
 		"description":              description,
 		"gaTrackingID":             h.cfg.GetString("analytics.gaTrackingID"),
 		"allowPrivateRepositories": h.cfg.GetBool("server.allowPrivateRepositories"),
-		"githubAuth":               h.cfg.GetBool("server.oauth.github.enabled"),
-		"googleAuth":               h.cfg.GetBool("server.oauth.google.enabled"),
-		"oidcAuth":                 h.cfg.GetBool("server.oauth.oidc.enabled"),
+		"githubAuth":               h.cfg.IsSet("server.oauth.github"),
+		"googleAuth":               h.cfg.IsSet("server.oauth.google"),
+		"oidcAuth":                 h.cfg.IsSet("server.oauth.oidc"),
 	}
 	if err := h.indexTmpl.Execute(w, data); err != nil {
 		h.logger.Error().Err(err).Msg("Error executing index template")


### PR DESCRIPTION
This reverts commit 79a4268a9f2388c2e811c815238578e1e851ac2b.