### PR TITLE
Use Chart's appVersion as imageTag default

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: 0.14.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/ci/chart-testing-values.yaml
+++ b/charts/artifact-hub/ci/chart-testing-values.yaml
@@ -1,0 +1,3 @@
+# `imageTag: latest` is used for the CI tests (with the GitHub action `helm/chart-testing-action`)
+# (since the Chart's appVersion - which is the default for `imageTag` - might not be released yet)
+imageTag: latest

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -23,7 +23,7 @@ spec:
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
       containers:
       - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag }}
+        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -26,7 +26,7 @@ spec:
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
       containers:
       - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag }}
+        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: hub
-          image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag }}
+          image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{- if .Values.hub.server.cacheDir }}
           env:

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
             command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
           containers:
           - name: scanner
-            image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag }}
+            image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
             imagePullPolicy: {{ .Values.pullPolicy }}
             {{- if .Values.scanner.cacheDir }}
             env:

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
             command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
           containers:
           - name: tracker
-            image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag }}
+            image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
             imagePullPolicy: {{ .Values.pullPolicy }}
             {{- if .Values.tracker.cacheDir }}
             env:

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -444,8 +444,9 @@
         },
         "imageTag": {
             "title": "Tag used when pulling images",
+            "description": "Defaults to the Chart's appVersion.",
             "type": "string",
-            "default": "latest"
+            "default": ""
         },
         "log": {
             "type": "object",
@@ -682,5 +683,5 @@
             "required": ["deploy", "persistence"]
         }
     },
-    "required": ["imageTag", "pullPolicy", "log", "db", "dbMigrator", "hub", "scanner", "tracker", "trivy", "postgresql"]
+    "required": ["pullPolicy", "log", "db", "dbMigrator", "hub", "scanner", "tracker", "trivy", "postgresql"]
 }

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -1,7 +1,7 @@
 nameOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
-imageTag: latest
+imageTag: ""
 pullPolicy: IfNotPresent
 
 log:


### PR DESCRIPTION
Using the imageTag `latest` can cause problems when up- or downgrading an installation.
Therefore this commit removes the default value (`latest`) from the `values.yaml` file and uses the Chart's `appVersion` by default.
Since the `appVersion` of ArtifactHub might not be released at the time of the Helm CI test execution, a new `ci` folder is introduced with values files specifically for the `helm/chart-testing-action` ([as described in their docs](https://github.com/helm/charts/blob/master/test/README.md#providing-custom-test-values)).
In the future this could also be used for performing multiple chart tests (with different configurations), f.e. when testing the default config folder and the newly introduced `/artifacthub/.cfg`).

Fixes #1064.