### PR TITLE
Fix missing prefix for default image tag based on appVersion

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.14.1
+version: 0.14.2
 appVersion: 0.14.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -23,7 +23,7 @@ spec:
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
       containers:
       - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
+        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -26,7 +26,7 @@ spec:
         command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
       containers:
       - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
+        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         env:
           - name: TERN_CONF

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -50,7 +50,7 @@ spec:
       {{- end }}
       containers:
         - name: hub
-          image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
+          image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{- if .Values.hub.server.cacheDir }}
           env:

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
             command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
           containers:
           - name: scanner
-            image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
+            image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
             imagePullPolicy: {{ .Values.pullPolicy }}
             {{- if .Values.scanner.cacheDir }}
             env:

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -30,7 +30,7 @@ spec:
             command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
           containers:
           - name: tracker
-            image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default .Chart.AppVersion }}
+            image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
             imagePullPolicy: {{ .Values.pullPolicy }}
             {{- if .Values.tracker.cacheDir }}
             env:

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -444,7 +444,7 @@
         },
         "imageTag": {
             "title": "Tag used when pulling images",
-            "description": "Defaults to the Chart's appVersion.",
+            "description": "Defaults to the Chart's appVersion, prefixed with a `v`.",
             "type": "string",
             "default": ""
         },


### PR DESCRIPTION
The docker images are prefixed with a "v". If the `imageTag` value is not explicitly set, it defaults to the Chart's `appVersion`.
The `appVersion` is a [semantic version](https://semver.org/spec/v2.0.0.html), the docker image tags are semantic versions prefixed with a `v` (f.e. `v0.14.1`). This PR ensures that the default tag uses the docker tag prefix.

Fixes bug introduced with #1068.