### PR TITLE
Readiness gates config not needed anymore

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: 0.15.0
 home: https://artifacthub.io
 icon: https://artifacthub.github.io/hub/chart/logo.png

--- a/charts/artifact-hub/values-production.yaml
+++ b/charts/artifact-hub/values-production.yaml
@@ -36,12 +36,6 @@ hub:
                 serviceName: hub
                 servicePort: 80
   deploy:
-    readinessGates:
-      # This readiness gate expects the ingress and service to have a static name.
-      # If dynamicResourceNamePrefixEnabled=true, the gate needs to be changed to the following format:
-      # target-health.alb.ingress.k8s.aws/<dynamic-prefix>hub_<dynamic-prefix>hub_80
-      # The "dynamic-prefix" is generated in the helper function `chart.resourceNamePrefix`.
-      - conditionType: target-health.alb.ingress.k8s.aws/hub_hub_80
     replicaCount: 3
     resources:
       requests:

--- a/charts/artifact-hub/values-staging.yaml
+++ b/charts/artifact-hub/values-staging.yaml
@@ -28,12 +28,6 @@ hub:
                 serviceName: hub
                 servicePort: 80
   deploy:
-    readinessGates:
-      # This readiness gate expects the ingress and service to have a static name.
-      # If dynamicResourceNamePrefixEnabled=true, the gate needs to be changed to the following format:
-      # target-health.alb.ingress.k8s.aws/<dynamic-prefix>hub_<dynamic-prefix>hub_80
-      # The "dynamic-prefix" is generated in the helper function `chart.resourceNamePrefix`.
-      - conditionType: target-health.alb.ingress.k8s.aws/hub_hub_80
     replicaCount: 2
     resources:
       requests:


### PR DESCRIPTION
Production and staging environments now use the AWS load balancer controller.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>