### PR TITLE
Scan the latest tag

### DIFF
--- a/docs/helm_annotations.md
+++ b/docs/helm_annotations.md
@@ -18,8 +18,6 @@ Use this annotation to indicate that this chart version contains security update
 
 Use this annotation to provide a list of the images used by this chart. Images listed will be scanned for security vulnerabilities. The security report generated will be available in the package detail view. It is possible to whitelist images so that they are not scanned by setting the `whitelisted` flag to true.
 
-Please note that images using the *latest* tag won't be scanned.
-
 - **artifacthub.io/crds** *(yaml string, see example below)*
 
 This annotation can be used to list the operator's CRDs. They will be visible in the package's detail view as cards.

--- a/docs/security_report.md
+++ b/docs/security_report.md
@@ -10,8 +10,6 @@ The security report may contain multiple images sections, one for each of the im
 
 To generate a security report of your package, it needs to include the containers images it uses. The location of this information varies from one package kind to another.
 
-**NOTE**: *images using the `latest` tag won't be scanned. Trivy recommends not to use this tag as it [causes problems with the cache](https://github.com/aquasecurity/trivy#image)*.
-
 ### Helm charts
 
 Images used by a Helm chart can be listed including a special annotation called `artifacthub.io/images` in the `Chart.yaml` file. You can find an example of how this is done in the Artifact Hub Helm chart [here](https://github.com/artifacthub/hub/blob/a3ffcb7cee0aa3923c3e4cf9bcf8ac0f2f437a2b/charts/artifact-hub/Chart.yaml#L25-L34). For more information please see the Artifact Hub [Helm annotations](https://github.com/artifacthub/hub/blob/master/docs/helm_annotations.md) documentation. The way this works may change when [Helm defines an official way to list the images](https://github.com/helm/helm/issues/7754).
@@ -53,4 +51,4 @@ If you want your application dependencies scanned, please make sure the relevant
 
 - *I can't see the security report for my package*
 
-Please make sure your images are **publicly available** and **not using the latest tag**. If your repository has just been added to Artifact Hub, it may take up to *30 mins* for it to be indexed. Once it has been indexed, it may take up to *15 extra minutes* for the initial security report of your packages to be generated. If you don't see it after **an hour** and the images your package lists meet the requirements, please file an [issue](https://github.com/artifacthub/hub/issues).
+Please make sure your images are **publicly available**. If your repository has just been added to Artifact Hub, it may take up to *30 mins* for it to be indexed. Once it has been indexed, it may take up to *15 extra minutes* for the initial security report of your packages to be generated. If you don't see it after **an hour** and the images your package lists meet the requirements, please file an [issue](https://github.com/artifacthub/hub/issues).

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/artifacthub/hub/internal/hub"
 )
@@ -27,11 +26,6 @@ func ScanSnapshot(
 	ec.Init(snapshot.RepositoryID)
 
 	for _, image := range snapshot.ContainersImages {
-		parts := strings.Split(image.Image, ":")
-		if len(parts) == 1 || parts[1] == "latest" {
-			ec.Append(snapshot.RepositoryID, fmt.Sprintf("latest tag not supported: %s", image.Image))
-			continue
-		}
 		reportData, err := scanner.Scan(image.Image)
 		if err != nil {
 			if errors.Is(err, ErrImageNotFound) {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -45,35 +45,6 @@ func TestScanSnapshot(t *testing.T) {
 		ecMock.AssertExpectations(t)
 	})
 
-	t.Run("image using latest tag", func(t *testing.T) {
-		t.Parallel()
-		scannerMock := &Mock{}
-		ecMock := &repo.ErrorsCollectorMock{}
-		ecMock.On("Init", repositoryID)
-		ecMock.On("Append", repositoryID, "latest tag not supported: repo/image:latest")
-
-		snapshot := &hub.SnapshotToScan{
-			RepositoryID: repositoryID,
-			PackageID:    packageID,
-			Version:      version,
-			ContainersImages: []*hub.ContainerImage{
-				{
-					Image: "repo/image:latest",
-				},
-			},
-		}
-		report, err := ScanSnapshot(ctx, scannerMock, snapshot, ecMock)
-		require.Nil(t, err)
-		assert.Equal(t, &hub.SnapshotSecurityReport{
-			PackageID: packageID,
-			Version:   version,
-			Full:      nil,
-			Summary:   nil,
-		}, report)
-		scannerMock.AssertExpectations(t)
-		ecMock.AssertExpectations(t)
-	})
-
 	t.Run("image not found", func(t *testing.T) {
 		t.Parallel()
 		scannerMock := &Mock{}


### PR DESCRIPTION
Trivy no longer has any issue with the latest tag. The issue was addressed a long time ago actually.
https://github.com/aquasecurity/trivy/pull/864