### PR TITLE
Reorganize some configuration values

### DIFF
--- a/.gitpod/tracker.yaml
+++ b/.gitpod/tracker.yaml
@@ -11,7 +11,4 @@ tracker:
   concurrency: 1
   repositoriesNames: []
   repositoriesKinds: []
-  imageStore: pg
   bypassDigestCheck: false
-  events:
-    trackingErrors: false

--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 0.17.0
+version: 0.17.1
 appVersion: 0.17.0
 kubeVersion: ">= 1.14.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/hub_secret.yaml
+++ b/charts/artifact-hub/templates/hub_secret.yaml
@@ -14,6 +14,17 @@ stringData:
       database: {{ .Values.db.database }}
       user: {{ .Values.db.user }}
       password: {{ .Values.db.password }}
+    email:
+      fromName: {{ .Values.email.fromName }}
+      from: {{ .Values.email.from }}
+      replyTo: {{ .Values.email.replyTo }}
+      smtp:
+        host: {{ .Values.email.smtp.host }}
+        port: {{ .Values.email.smtp.port }}
+        username: {{ .Values.email.smtp.username }}
+        password: {{ .Values.email.smtp.password }}
+    images:
+      store: {{ .Values.images.store }}
     server:
       allowPrivateRepositories: {{ .Values.hub.server.allowPrivateRepositories }}
       baseURL: {{ .Values.hub.server.baseURL }}
@@ -58,14 +69,5 @@ stringData:
           scopes: {{ .Values.hub.server.oauth.oidc.scopes }}
         {{- end }}
       xffIndex: {{ .Values.hub.server.xffIndex }}
-    email:
-      fromName: {{ .Values.hub.email.fromName }}
-      from: {{ .Values.hub.email.from }}
-      replyTo: {{ .Values.hub.email.replyTo }}
-      smtp:
-        host: {{ .Values.hub.email.smtp.host }}
-        port: {{ .Values.hub.email.smtp.port }}
-        username: {{ .Values.hub.email.smtp.username }}
-        password: {{ .Values.hub.email.smtp.password }}
     analytics:
       gaTrackingID: {{ .Values.hub.analytics.gaTrackingID }}

--- a/charts/artifact-hub/templates/scanner_secret.yaml
+++ b/charts/artifact-hub/templates/scanner_secret.yaml
@@ -14,10 +14,11 @@ stringData:
       database: {{ .Values.db.database }}
       user: {{ .Values.db.user }}
       password: {{ .Values.db.password }}
+    creds:
+      dockerUsername: {{ .Values.creds.dockerUsername }}
+      dockerPassword: {{ .Values.creds.dockerPassword }}
+    events:
+      scanningErrors: {{ .Values.events.scanningErrors }}
     scanner:
       concurrency: {{ .Values.scanner.concurrency }}
       trivyURL: {{ .Values.scanner.trivyURL | default (printf "http://%s%s:8081" (include "chart.resourceNamePrefix" .) "trivy") }}
-      dockerUsername: {{ .Values.scanner.dockerUsername }}
-      dockerPassword: {{ .Values.scanner.dockerPassword }}
-      events:
-        scanningErrors: {{ .Values.scanner.events.scanningErrors }}

--- a/charts/artifact-hub/templates/tracker_secret.yaml
+++ b/charts/artifact-hub/templates/tracker_secret.yaml
@@ -14,12 +14,14 @@ stringData:
       database: {{ .Values.db.database }}
       user: {{ .Values.db.user }}
       password: {{ .Values.db.password }}
+    creds:
+      githubToken: {{ .Values.creds.githubToken }}
+    images:
+      store: {{ .Values.images.store }}
+    events:
+      trackingErrors: {{ .Values.events.trackingErrors }}
     tracker:
       concurrency: {{ .Values.tracker.concurrency }}
       repositoriesNames: {{ .Values.tracker.repositoriesNames }}
       repositoriesKinds: {{ .Values.tracker.repositoriesKinds }}
-      imageStore: {{ .Values.tracker.imageStore }}
       bypassDigestCheck: {{ .Values.tracker.bypassDigestCheck }}
-      events:
-        trackingErrors: {{ .Values.tracker.events.trackingErrors }}
-      githubToken: {{ .Values.tracker.githubToken }}

--- a/charts/artifact-hub/values-production.yaml
+++ b/charts/artifact-hub/values-production.yaml
@@ -2,6 +2,10 @@ log:
   level: debug
   pretty: false
 
+events:
+  scanningErrors: true
+  trackingErrors: true
+
 dbMigrator:
   loadSampleData: false
 
@@ -58,8 +62,6 @@ scanner:
       requests:
         cpu: 2
         memory: 4000Mi
-  events:
-    scanningErrors: true
 
 tracker:
   cronjob:
@@ -67,8 +69,6 @@ tracker:
       requests:
         cpu: 2
         memory: 4000Mi
-  events:
-    trackingErrors: true
 
 trivy:
   deploy:

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -3,6 +3,26 @@
     "title": "Artifact Hub Chart JSON Schema",
     "type": "object",
     "properties": {
+        "creds": {
+            "type": "object",
+            "properties": {
+                "dockerPassword": {
+                    "title": "Docker registry password",
+                    "type": "string",
+                    "default": ""
+                },
+                "dockerUsername": {
+                    "title": "Docker registry username",
+                    "type": "string",
+                    "default": ""
+                },
+                "githubToken": {
+                    "title": "Authentication token used in Github requests (increases rate limit)",
+                    "type": "string",
+                    "default": ""
+                }
+            }
+        },
         "db": {
             "title": "Database configuration",
             "type": "object",
@@ -74,6 +94,54 @@
             },
             "required": ["job", "loadSampleData", "configDir"]
         },
+        "email": {
+            "type": "object",
+            "properties": {
+                "from": {
+                    "title": "From address used in emails",
+                    "description": "This field is required if you want to enable email sending in Artifact Hub.",
+                    "type": "string",
+                    "default": ""
+                },
+                "fromName": {
+                    "title": "From name used in emails",
+                    "type": "string",
+                    "default": ""
+                },
+                "replyTo": {
+                    "title": "Reply-to address used in emails",
+                    "type": "string",
+                    "default": ""
+                },
+                "smtp": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "title": "SMTP host",
+                            "description": "This field is required if you want to enable email sending in Artifact Hub.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "password": {
+                            "title": "SMTP password",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "port": {
+                            "title": "SMTP port",
+                            "description": "This field is required if you want to enable email sending in Artifact Hub.",
+                            "type": "integer",
+                            "default": 587
+                        },
+                        "username": {
+                            "title": "SMTP username",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                }
+            }
+        },
         "fullnameOverride": {
             "type": "string",
             "title": "Fullname override",
@@ -85,6 +153,22 @@
             "title": "Enable dynamic resource name prefix",
             "description": "Enabling the dynamic resource name prefix ensures that the resources are named dynamically based on the Helm installation's name. This allows multiple installations of this chart in a single Kubernetes namespace. The prefix can be defined by using the `fullnameOverride`.",
             "default": false
+        },
+        "events": {
+            "type": "object",
+            "properties": {
+                "scanningErrors": {
+                    "title": "Enable repository scanning errors events",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trackingErrors": {
+                    "title": "Enable repository tracking errors events",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "required": ["scanningErrors", "trackingErrors"]
         },
         "hub": {
             "title": "Hub configuration",
@@ -136,54 +220,6 @@
                         }
                     },
                     "required": ["image", "replicaCount", "resources"]
-                },
-                "email": {
-                    "type": "object",
-                    "properties": {
-                        "from": {
-                            "title": "From address used in emails",
-                            "description": "This field is required if you want to enable email sending in Artifact Hub.",
-                            "type": "string",
-                            "default": ""
-                        },
-                        "fromName": {
-                            "title": "From name used in emails",
-                            "type": "string",
-                            "default": ""
-                        },
-                        "replyTo": {
-                            "title": "Reply-to address used in emails",
-                            "type": "string",
-                            "default": ""
-                        },
-                        "smtp": {
-                            "type": "object",
-                            "properties": {
-                                "host": {
-                                    "title": "SMTP host",
-                                    "description": "This field is required if you want to enable email sending in Artifact Hub.",
-                                    "type": "string",
-                                    "default": ""
-                                },
-                                "password": {
-                                    "title": "SMTP password",
-                                    "type": "string",
-                                    "default": ""
-                                },
-                                "port": {
-                                    "title": "SMTP port",
-                                    "description": "This field is required if you want to enable email sending in Artifact Hub.",
-                                    "type": "integer",
-                                    "default": 587
-                                },
-                                "username": {
-                                    "title": "SMTP username",
-                                    "type": "string",
-                                    "default": ""
-                                }
-                            }
-                        }
-                    }
                 },
                 "ingress": {
                     "type": "object",
@@ -485,6 +521,18 @@
             "type": "string",
             "default": ""
         },
+        "images": {
+            "type": "object",
+            "properties": {
+                "store": {
+                    "title": "Store for images",
+                    "type": "string",
+                    "default": "pg",
+                    "enum": ["pg"]
+                }
+            },
+            "required": ["store"]
+        },
         "log": {
             "type": "object",
             "properties": {
@@ -559,26 +607,6 @@
                     },
                     "required": ["image", "resources"]
                 },
-                "dockerPassword": {
-                    "title": "Docker registry password",
-                    "type": "string",
-                    "default": ""
-                },
-                "dockerUsername": {
-                    "title": "Docker registry username",
-                    "type": "string",
-                    "default": ""
-                },
-                "events": {
-                    "type": "object",
-                    "properties": {
-                        "scanningErrors": {
-                            "title": "Enable repository scanning errors events",
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                },
                 "trivyURL": {
                     "title": "Trivy server url",
                     "type": "string",
@@ -586,7 +614,7 @@
                     "default": ""
                 }
             },
-            "required": ["concurrency", "configDir", "cronjob", "events", "trivyURL"]
+            "required": ["concurrency", "configDir", "cronjob", "trivyURL"]
         },
         "tracker": {
             "title": "Tracker configuration",
@@ -642,27 +670,6 @@
                     },
                     "required": ["image", "resources"]
                 },
-                "events": {
-                    "type": "object",
-                    "properties": {
-                        "trackingErrors": {
-                            "title": "Enable repository tracking errors events",
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                },
-                "githubToken": {
-                    "title": "Authentication token used in Github requests (increases rate limit)",
-                    "type": "string",
-                    "default": ""
-                },
-                "imageStore": {
-                    "title": "Store for images",
-                    "type": "string",
-                    "default": "pg",
-                    "enum": ["pg"]
-                },
                 "repositoriesKinds": {
                     "title": "Repositories kinds to process ([] = all)",
                     "description": "The following kinds are supported at the moment: falco, helm, olm, opa, tbaction, krew, helm-plugin, tekton-task",
@@ -683,7 +690,7 @@
                     "uniqueItems": true
                 }
             },
-            "required": ["bypassDigestCheck", "configDir", "concurrency", "cronjob", "events", "imageStore", "repositoriesKinds", "repositoriesNames"]
+            "required": ["bypassDigestCheck", "configDir", "concurrency", "cronjob", "repositoriesKinds", "repositoriesNames"]
         },
         "trivy": {
             "title": "Trivy configuration",
@@ -731,5 +738,5 @@
             "required": ["deploy", "persistence"]
         }
     },
-    "required": ["pullPolicy", "log", "db", "dbMigrator", "hub", "scanner", "tracker", "trivy", "postgresql"]
+    "required": ["db", "dbMigrator", "hub", "images", "log", "postgresql", "pullPolicy", "tracker", "trivy", "scanner"]
 }

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -16,6 +16,28 @@ db:
   user: postgres
   password: postgres
 
+email:
+  fromName: ""
+  from: ""
+  replyTo: ""
+  smtp:
+    host: ""
+    port: 587
+    username: ""
+    password: ""
+
+creds:
+  dockerUsername: ""
+  dockerPassword: ""
+  githubToken: ""
+
+images:
+  store: pg
+
+events:
+  scanningErrors: false
+  trackingErrors: false
+
 dbMigrator:
   job:
     image:
@@ -85,15 +107,6 @@ hub:
           - profile
           - email
     xffIndex: 0
-  email:
-    fromName: ""
-    from: ""
-    replyTo: ""
-    smtp:
-      host: ""
-      port: 587
-      username: ""
-      password: ""
   analytics:
     gaTrackingID: ""
 
@@ -106,10 +119,6 @@ scanner:
   trivyURL: ""
   cacheDir: ""
   configDir: "/home/scanner/.cfg"
-  dockerUsername: ""
-  dockerPassword: ""
-  events:
-    scanningErrors: false
 
 tracker:
   cronjob:
@@ -121,11 +130,7 @@ tracker:
   concurrency: 10
   repositoriesNames: []
   repositoriesKinds: []
-  imageStore: pg
   bypassDigestCheck: false
-  events:
-    trackingErrors: false
-  githubToken: ""
 
 trivy:
   deploy:

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -72,7 +72,7 @@ func main() {
 	pm := pkg.NewManager(db)
 	hc := &http.Client{Timeout: 10 * time.Second}
 	githubMaxRequestsPerHour := githubMaxRequestsPerHourUnauthenticated
-	if cfg.GetString("tracker.githubToken") != "" {
+	if cfg.GetString("creds.githubToken") != "" {
 		githubMaxRequestsPerHour = githubMaxRequestsPerHourAuthenticated
 	}
 	githubRL := rate.NewLimiter(rate.Every(1*time.Hour), githubMaxRequestsPerHour)

--- a/configs/scanner.yaml
+++ b/configs/scanner.yaml
@@ -7,8 +7,9 @@ db:
   port: "5432"
   database: hub
   user: postgres
+creds:
+  dockerUsername: ""
+  dockerPassword: ""
 scanner:
   concurrency: 10
   trivyURL: http://trivy:8081
-  dockerUsername: ""
-  dockerPassword: ""

--- a/configs/tracker.yaml
+++ b/configs/tracker.yaml
@@ -11,7 +11,4 @@ tracker:
   concurrency: 10
   repositoriesNames: []
   repositoriesKinds: []
-  imageStore: pg
   bypassDigestCheck: false
-  events:
-    trackingErrors: false

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -147,10 +147,7 @@ tracker:
   concurrency: 1
   repositoriesNames: []
   repositoriesKinds: []
-  imageStore: pg
   bypassDigestCheck: false
-  events:
-    trackingErrors: false
 ```
 
 Once the configuration file is ready, it's time to launch the `tracker` for the first time:

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -71,16 +71,21 @@ helm install \
   --values values-<ENVIRONMENT>.yaml \
   --namespace <NAMESPACE_NAME> \
   --set imageTag=<GIT_SHA> \
-  --set hub.deploy.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/hub \
-  --set dbMigrator.job.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/db-migrator \
-  --set tracker.cronjob.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/tracker \
-  --set tracker.githubToken=<GITHUB_TOKEN> \
-  --set scanner.cronjob.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/scanner \
-  --set scanner.dockerUsername=<DOCKER_USERNAME> \
-  --set scanner.dockerPassword=<DOCKER_PASSWORD> \
+  --set creds.dockerUsername=<DOCKER_USERNAME> \
+  --set creds.dockerPassword=<DOCKER_PASSWORD> \
+  --set creds.githubToken=<GITHUB_TOKEN> \
   --set db.user=<DB_USER> \
   --set db.host=<DB_HOST> \
   --set db.password=<DB_PASSWORD> \
+  --set email.fromName="Artifact Hub" \
+  --set email.from=hub@artifacthub.io \
+  --set email.replyTo=no-reply@artifacthub.io \
+  --set email.smtp.host=<SMTP_HOST> \
+  --set email.smtp.port=<SMTP_PORT> \
+  --set email.smtp.username=<SMTP_USERNAME> \
+  --set email.smtp.password=<SMTP_PASSWORD> \
+  --set dbMigrator.job.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/db-migrator \
+  --set hub.deploy.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/hub \
   --set hub.ingress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"=<CERTIFICATE_ARN> \
   --set hub.ingress.annotations."alb\.ingress\.kubernetes\.io/wafv2-acl-arn"=<ACL_ARN> \
   --set hub.server.cookie.hashKey=<COOKIE_HASHKEY> \
@@ -88,18 +93,13 @@ helm install \
   --set hub.server.csrf.authKey=<CSRF_AUTHKEY> \
   --set hub.server.csrf.secure=true \
   --set hub.server.xffIndex=-2 \
-  --set hub.email.fromName="Artifact Hub" \
-  --set hub.email.from=hub@artifacthub.io \
-  --set hub.email.replyTo=no-reply@artifacthub.io \
-  --set hub.email.smtp.host=<SMTP_HOST> \
-  --set hub.email.smtp.port=<SMTP_PORT> \
-  --set hub.email.smtp.username=<SMTP_USERNAME> \
-  --set hub.email.smtp.password=<SMTP_PASSWORD> \
   --set hub.server.oauth.github.clientID=<GITHUB_CLIENT_ID> \
   --set hub.server.oauth.github.clientSecret=<GITHUB_CLIENT_SECRET> \
   --set hub.server.oauth.google.clientID=<GOOGLE_CLIENT_ID> \
   --set hub.server.oauth.google.clientSecret=<GOOGLE_CLIENT_SECRET> \
   --set hub.analytics.gaTrackingID=<GA_TRACKING_ID> \
+  --set tracker.cronjob.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/tracker \
+  --set scanner.cronjob.image.repository=<AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com/scanner \
 <RELEASE_NAME> .
 ```
 

--- a/internal/img/pg/pg.go
+++ b/internal/img/pg/pg.go
@@ -84,7 +84,7 @@ func (s *ImageStore) DownloadAndSaveImage(ctx context.Context, imageURL string) 
 		}
 
 		// Download it from source and store it in the cache.
-		githubToken := s.cfg.GetString("tracker.githubToken")
+		githubToken := s.cfg.GetString("creds.githubToken")
 		data, err = img.Download(ctx, s.hc, githubToken, s.githubRL, imageURL)
 		if err != nil {
 			s.errorsCache.Add(imageURL, err)

--- a/internal/scanner/trivy.go
+++ b/internal/scanner/trivy.go
@@ -48,8 +48,8 @@ func (s *TrivyScanner) Scan(image string) ([]byte, error) {
 	}
 	if strings.HasSuffix(ref.Context().Registry.Name(), "docker.io") {
 		cmd.Env = append(cmd.Env,
-			"TRIVY_USERNAME="+s.Cfg.GetString("scanner.dockerUsername"),
-			"TRIVY_PASSWORD="+s.Cfg.GetString("scanner.dockerPassword"),
+			"TRIVY_USERNAME="+s.Cfg.GetString("creds.dockerUsername"),
+			"TRIVY_PASSWORD="+s.Cfg.GetString("creds.dockerPassword"),
 		)
 	}
 

--- a/internal/tracker/source/helm/helm.go
+++ b/internal/tracker/source/helm/helm.go
@@ -253,7 +253,7 @@ func (s *TrackerSource) loadChartArchive(u *url.URL) (*chart.Chart, error) {
 		req, _ := http.NewRequest("GET", u.String(), nil)
 		if u.Host == "github.com" || u.Host == "raw.githubusercontent.com" {
 			// Authenticate and rate limit requests to Github
-			githubToken := s.i.Svc.Cfg.GetString("tracker.githubToken")
+			githubToken := s.i.Svc.Cfg.GetString("creds.githubToken")
 			if githubToken != "" {
 				req.Header.Set("Authorization", fmt.Sprintf("token %s", githubToken))
 			}

--- a/internal/util/image.go
+++ b/internal/util/image.go
@@ -16,7 +16,7 @@ func SetupImageStore(
 	hc img.HTTPClient,
 	githubRL *rate.Limiter,
 ) (img.Store, error) {
-	imageStore := cfg.GetString("tracker.imageStore")
+	imageStore := cfg.GetString("images.store")
 	switch imageStore {
 	case "pg":
 		return pg.NewImageStore(cfg, db, hc, githubRL), nil

--- a/internal/util/image_test.go
+++ b/internal/util/image_test.go
@@ -12,14 +12,14 @@ func TestSetupImageStore(t *testing.T) {
 
 	// Check a valid image store provider must be provided
 	cfg := viper.New()
-	cfg.Set("tracker.imageStore", "invalid")
+	cfg.Set("images.store", "invalid")
 	imageStore, err := SetupImageStore(cfg, nil, nil, nil)
 	require.Error(t, err)
 	require.Nil(t, imageStore)
 
 	// Check image store was setup successfully
 	cfg = viper.New()
-	cfg.Set("tracker.imageStore", "pg")
+	cfg.Set("images.store", "pg")
 	imageStore, err = SetupImageStore(cfg, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, imageStore)


### PR DESCRIPTION
This PR addresses the following problems:

- Some config values used by internal packages are component dependent
- Some config sections are (or may eventually be) duplicated in multiple components sections

The following changes have been applied:

- Email configuration block has been moved out of the `hub` section to the root of the values file.
- Github token has been moved out of the `tracker` section to a new `creds` section at the root of the values file.
- Docker username and password have been moved out of the `scanner` section to the new `creds` section.
- Image store has been moved out of the `tracker` section to a new `images` section at the root of the values file.
- Tracking and scanning events have been moved out of the `tracker` and `scanner` sections respectively to a new `events` section at the root of the values file.

**Please note that existing deployments may need to update some or all of these values to avoid breaking some features.**

Closes #1186

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>