### PR TITLE
Added OpenAPI spec linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs:
       - linter-backend
+      - linter-openapi
       - tests-database
       - tests-backend
       - tests-frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_OPENAPI: true
-          FILTER_REGEX_INCLUDE: docs/api/.*
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_INCLUDE: docs/api/openapi.yaml
 
   tests-database:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@master
-      - name: Lint Code Base
+      - name: Lint OpenAPI specs
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ jobs:
           version: v1.37
           args: --timeout 5m
 
+  linter-openapi:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@master
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_OPENAPI: true
+          FILTER_REGEX_INCLUDE: docs/api/.*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   tests-database:
     runs-on: ubuntu-20.04
     container:


### PR DESCRIPTION
A quick follow-up on #1242.

To solve such issues with the API spec in a sustainable way I thought it might be a good idea to add a separate linting step to the CI workflow in order to find issues with the spec during a pipeline run.

I added some linting via the GitHub maintained [Super-Linter](https://github.com/marketplace/actions/super-linter) and restricted its capabilities to OpenAPI spec's only and the `docs/api` directory.

However the linter is still spotting errors in the current master version, see the result from a run on my fork for reference:
```
✖ 189 problems (22 errors, 167 warnings, 0 infos, 0 hints)
```

I tried to provide you with a minimal working example leaving the detailed configuration and if you want to include such a check at all up to you. Hope you find it helpful otherwise you can close this one :wink: