### PR TITLE
Improve scanner errors logging

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha512"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -31,11 +30,6 @@ func ScanSnapshot(
 	for _, image := range s.ContainersImages {
 		reportData, err := scanner.Scan(image.Image)
 		if err != nil {
-			if errors.Is(err, ErrImageNotFound) {
-				err := fmt.Sprintf("%s: %s (package %s:%s)", err.Error(), image.Image, s.PackageName, s.Version)
-				ec.Append(s.RepositoryID, err)
-				continue
-			}
 			err := fmt.Errorf("error scanning image %s: %w (package %s:%s)", image.Image, err, s.PackageName, s.Version)
 			ec.Append(s.RepositoryID, err.Error())
 			return nil, err

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -47,37 +47,6 @@ func TestScanSnapshot(t *testing.T) {
 		ecMock.AssertExpectations(t)
 	})
 
-	t.Run("image not found", func(t *testing.T) {
-		t.Parallel()
-		scannerMock := &Mock{}
-		scannerMock.On("Scan", image).Return(nil, ErrImageNotFound)
-		ecMock := &repo.ErrorsCollectorMock{}
-		ecMock.On("Init", repositoryID)
-		ecMock.On("Append", repositoryID, "image not found: repo/image:tag (package pkg1:1.0.0)")
-
-		snapshot := &hub.SnapshotToScan{
-			RepositoryID: repositoryID,
-			PackageID:    packageID,
-			PackageName:  packageName,
-			Version:      version,
-			ContainersImages: []*hub.ContainerImage{
-				{
-					Image: image,
-				},
-			},
-		}
-		report, err := ScanSnapshot(ctx, scannerMock, snapshot, ecMock)
-		require.Nil(t, err)
-		assert.Equal(t, &hub.SnapshotSecurityReport{
-			PackageID: packageID,
-			Version:   version,
-			Full:      nil,
-			Summary:   nil,
-		}, report)
-		scannerMock.AssertExpectations(t)
-		ecMock.AssertExpectations(t)
-	})
-
 	t.Run("error unmarshalling report", func(t *testing.T) {
 		t.Parallel()
 		scannerMock := &Mock{}

--- a/internal/scanner/trivy.go
+++ b/internal/scanner/trivy.go
@@ -3,7 +3,6 @@ package scanner
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,10 +11,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/spf13/viper"
 )
-
-// ErrImageNotFound represents that the image provided was not found in the
-// repository.
-var ErrImageNotFound = errors.New("image not found")
 
 // TrivyScanner is an implementation of the Scanner interface that uses Trivy.
 type TrivyScanner struct {
@@ -55,9 +50,6 @@ func (s *TrivyScanner) Scan(image string) ([]byte, error) {
 
 	// Run trivy command
 	if err := cmd.Run(); err != nil {
-		if strings.Contains(stderr.String(), "Cannot connect to the Docker daemon") {
-			return nil, ErrImageNotFound
-		}
 		return nil, fmt.Errorf("error running trivy on image %s: %w: %s", image, err, stderr.String())
 	}
 	return stdout.Bytes(), nil


### PR DESCRIPTION
Errors returned from `trivy` are now added to the scanning errors logs
as-is. In addition to this, no security report for a package will be
generated if the scanning of one of the images fails for any reason.
Before, when the error was `image not found`, we were still generating
the report, which could lead to incomplete and misleading reports.

Closes #1387

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>