### PR TITLE
Bump Trivy to 0.22.0

### DIFF
--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,6 +1,6 @@
 FROM gitpod/workspace-postgres
 
-RUN wget https://github.com/aquasecurity/trivy/releases/download/v0.21.3/trivy_0.21.3_Linux-64bit.deb && \
-    sudo dpkg -i trivy_0.21.3_Linux-64bit.deb
+RUN wget https://github.com/aquasecurity/trivy/releases/download/v0.22.0/trivy_0.22.0_Linux-64bit.deb && \
+    sudo dpkg -i trivy_0.22.0_Linux-64bit.deb
 RUN sudo wget https://github.com/operator-framework/operator-registry/releases/download/v1.19.5/linux-amd64-opm -O /usr/local/bin/opm && \
     sudo chmod +x /usr/local/bin/opm

--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.5.1-0
+version: 1.5.1-1
 appVersion: 1.5.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io
@@ -75,7 +75,7 @@ annotations:
     - name: scanner
       image: artifacthub/scanner:v1.5.0
     - name: trivy
-      image: aquasec/trivy:0.21.3
+      image: aquasec/trivy:0.22.0
   artifacthub.io/links: |
     - name: source
       url: https://github.com/artifacthub/hub

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -805,7 +805,7 @@
                         "image": {
                             "title": "Trivy container image",
                             "type": "string",
-                            "default": "aquasec/trivy:0.21.3"
+                            "default": "aquasec/trivy:0.22.0"
                         },
                         "resources": {
                             "title": "Trivy pod resource requirements",

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -263,7 +263,7 @@ tracker:
 # Trivy configuration
 trivy:
   deploy:
-    image: aquasec/trivy:0.21.3
+    image: aquasec/trivy:0.22.0
     resources: {}
   persistence:
     enabled: false

--- a/cmd/scanner/Dockerfile
+++ b/cmd/scanner/Dockerfile
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /scanner .
 # Trivy installer
 FROM alpine:3.14 AS trivy-installer
 RUN apk --no-cache add curl
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin v0.21.3
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin v0.22.0
 
 # Final stage
 FROM alpine:3.14

--- a/docs/security_report.md
+++ b/docs/security_report.md
@@ -24,7 +24,7 @@ Images used by these kinds of packages can be listed using the `containersImages
 
 ## Application dependencies
 
-Trivy also scans [applications dependencies](https://aquasecurity.github.io/trivy/v0.21.3/vulnerability/detection/language/) for vulnerabilities. To do that, it inspects the files that contain the applications dependencies and the versions used. Please see the [language-specific packages](https://aquasecurity.github.io/trivy/v0.21.3/vulnerability/detection/language/) section in the Trivy documentation (image column) for a full list of the applications dependencies supported.
+Trivy also scans [applications dependencies](https://aquasecurity.github.io/trivy/v0.22.0/vulnerability/detection/language/) for vulnerabilities. To do that, it inspects the files that contain the applications dependencies and the versions used. Please see the [language-specific packages](https://aquasecurity.github.io/trivy/v0.22.0/vulnerability/detection/language/) section in the Trivy documentation (image column) for a full list of the applications dependencies supported.
 
 If you want your application dependencies scanned, please make sure the relevant files are included in your final images. The security report will include a target for each of them.
 


### PR DESCRIPTION
This provides support for scanning containers based on SLE BCI which
use RPM NDB databases.

Signed-off-by: Dirk Müller <dirk@dmllr.de>