### PR TITLE
Some improvements for Kubewarden policies packages

### DIFF
--- a/cmd/ah/lint.go
+++ b/cmd/ah/lint.go
@@ -163,7 +163,7 @@ func lintGeneric(basePath string, kind hub.RepositoryKind) *lintReport {
 
 		// Get package version metadata and prepare entry package
 		mdFilePath := filepath.Join(pkgPath, hub.PackageMetadataFile)
-		md, err := pkg.GetPackageMetadata(mdFilePath)
+		md, err := pkg.GetPackageMetadata(kind, mdFilePath)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				return nil

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -446,6 +446,8 @@ In the previous case, even the `package1` directory could be omitted. The reason
 
 Each package version **needs** an `artifacthub-pkg.yml` metadata file. Please see the file [spec](https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml) and the [Kubewarden annotations documentation](https://github.com/artifacthub/hub/blob/master/docs/kubewarden_annotations.md) for more details. The [artifacthub-repo.yml](https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml) repository metadata file shown above can be used to setup features like [Verified Publisher](#verified-publisher) or [Ownership claim](#ownership-claim). This file must be located at `/path/to/packages`.
 
+The [Artifact Hub metadata file](https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml) allows defining containers images. Kubewarden policies packages are **required** to provide an image named `policy` that points to the image containing the policy. Packages can optionally provide an alternative location for the policy image by defining a second image named `policy-alternative-location`. Artifact Hub will check if the images provided have been signed with `cosign` and will consider the package to be *signed* when **all** images are signed.
+
 Once you have added your repository, you are all set up. As you add new versions of your policies packages or even new packages to your git repository, they'll be automatically indexed and listed in Artifact Hub.
 
 The following repositories can be used as a reference:

--- a/internal/pkg/metadata_test.go
+++ b/internal/pkg/metadata_test.go
@@ -13,7 +13,7 @@ import (
 func TestGetPackageMetadata(t *testing.T) {
 	t.Run("error reading package metadata file", func(t *testing.T) {
 		t.Parallel()
-		_, err := GetPackageMetadata("testdata/not-exists")
+		_, err := GetPackageMetadata(hub.Keptn, "testdata/not-exists")
 		assert.Error(t, err)
 		assert.Equal(t, "error reading package metadata file: open testdata/not-exists.yaml: no such file or directory", err.Error())
 		assert.True(t, errors.Is(err, os.ErrNotExist))
@@ -21,27 +21,27 @@ func TestGetPackageMetadata(t *testing.T) {
 
 	t.Run("error unmarshaling package metadata file", func(t *testing.T) {
 		t.Parallel()
-		_, err := GetPackageMetadata("testdata/invalid")
+		_, err := GetPackageMetadata(hub.Keptn, "testdata/invalid")
 		assert.Error(t, err)
 		assert.Equal(t, "error unmarshaling package metadata file: yaml: line 2: found unexpected end of stream", err.Error())
 	})
 
 	t.Run("error validating package metadata file", func(t *testing.T) {
 		t.Parallel()
-		_, err := GetPackageMetadata("testdata/no-version")
+		_, err := GetPackageMetadata(hub.Keptn, "testdata/no-version")
 		assert.Error(t, err)
 		assert.Equal(t, "error validating package metadata file: 5 errors occurred:\n\t* invalid metadata: version not provided\n\t* invalid metadata: name not provided\n\t* invalid metadata: display name not provided\n\t* invalid metadata: createdAt not provided\n\t* invalid metadata: description not provided\n\n", err.Error())
 	})
 
 	t.Run("success with .yml", func(t *testing.T) {
 		t.Parallel()
-		_, err := GetPackageMetadata("testdata/valid1")
+		_, err := GetPackageMetadata(hub.Keptn, "testdata/valid1")
 		assert.NoError(t, err)
 	})
 
 	t.Run("success with .yaml", func(t *testing.T) {
 		t.Parallel()
-		_, err := GetPackageMetadata("testdata/valid2")
+		_, err := GetPackageMetadata(hub.Keptn, "testdata/valid2")
 		assert.NoError(t, err)
 	})
 }
@@ -203,10 +203,12 @@ func TestPreparePackageFromMetadata(t *testing.T) {
 func TestValidatePackageMetadata(t *testing.T) {
 	t.Run("invalid metadata", func(t *testing.T) {
 		testCases := []struct {
+			kind           hub.RepositoryKind
 			md             *hub.PackageMetadata
 			expectedErrors []string
 		}{
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{},
 				[]string{
 					"invalid metadata: version not provided",
@@ -217,6 +219,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version: "invalid",
 				},
@@ -229,6 +232,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version: "1.0.0",
 				},
@@ -240,6 +244,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version: "1.0.0",
 					Name:    "pkg1",
@@ -251,6 +256,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -262,6 +268,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -274,6 +281,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -285,6 +293,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -302,6 +311,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -317,6 +327,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -335,6 +346,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -352,6 +364,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -375,6 +388,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -398,6 +412,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 				},
 			},
 			{
+				hub.Keptn,
 				&hub.PackageMetadata{
 					Version:     "1.0.0",
 					Name:        "pkg1",
@@ -411,7 +426,89 @@ func TestValidatePackageMetadata(t *testing.T) {
 					},
 				},
 				[]string{
-					"invalid container image: could not parse reference",
+					"invalid image reference: could not parse reference",
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+				},
+				[]string{
+					`"policy" image not provided`,
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "something",
+							Image: "registry.io/namespace/something:tag",
+						},
+					},
+				},
+				[]string{
+					`"policy" image not provided`,
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "policy",
+							Image: "registry.io/namespace/policy:tag",
+						},
+						{
+							Name:  "something",
+							Image: "registry.io/namespace/something:tag",
+						},
+					},
+				},
+				[]string{
+					`only "policy" and "policy-alternative-location" images can be provided`,
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "policy",
+							Image: "registry.io/namespace/policy:tag",
+						},
+						{
+							Name:  "policy-alternative-location",
+							Image: "registry2.io/namespace/policy:tag",
+						},
+						{
+							Name:  "something",
+							Image: "registry.io/namespace/something:tag",
+						},
+					},
+				},
+				[]string{
+					`only "policy" and "policy-alternative-location" images can be provided`,
 				},
 			},
 		}
@@ -419,7 +516,7 @@ func TestValidatePackageMetadata(t *testing.T) {
 			tc := tc
 			t.Run(strconv.Itoa(i), func(t *testing.T) {
 				t.Parallel()
-				err := ValidatePackageMetadata(tc.md)
+				err := ValidatePackageMetadata(tc.kind, tc.md)
 				assert.True(t, errors.Is(err, ErrInvalidMetadata))
 				for _, expectedErr := range tc.expectedErrors {
 					assert.Contains(t, err.Error(), expectedErr)
@@ -429,27 +526,96 @@ func TestValidatePackageMetadata(t *testing.T) {
 	})
 
 	t.Run("valid metadata", func(t *testing.T) {
-		t.Parallel()
-		md := &hub.PackageMetadata{
-			Version:     "1.0.0",
-			Name:        "pkg1",
-			DisplayName: "Package 1",
-			CreatedAt:   "2006-01-02T15:04:05Z",
-			Description: "Package description",
-			Changes: []*hub.Change{
-				{
-					Kind:        "Added",
-					Description: "feature 1",
-					Links: []*hub.Link{
+		testCases := []struct {
+			kind hub.RepositoryKind
+			md   *hub.PackageMetadata
+		}{
+			{
+				hub.Keptn,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "Package description",
+					Changes: []*hub.Change{
 						{
-							Name: "link1",
-							URL:  "https://link1.url",
+							Kind:        "Added",
+							Description: "feature 1",
+							Links: []*hub.Link{
+								{
+									Name: "link1",
+									URL:  "https://link1.url",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "policy",
+							Image: "registry.io/namespace/policy:tag",
+						},
+					},
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "policy",
+							Image: "registry.io/namespace/policy:tag",
+						},
+						{
+							Name:  "policy-alternative-location",
+							Image: "registry2.io/namespace/policy:tag",
+						},
+					},
+				},
+			},
+			{
+				hub.Kubewarden,
+				&hub.PackageMetadata{
+					Version:     "1.0.0",
+					Name:        "pkg1",
+					DisplayName: "Package 1",
+					CreatedAt:   "2006-01-02T15:04:05Z",
+					Description: "description",
+					ContainersImages: []*hub.ContainerImage{
+						{
+							Name:  "policy-alternative-location",
+							Image: "registry2.io/namespace/policy:tag",
+						},
+						{
+							Name:  "policy",
+							Image: "registry.io/namespace/policy:tag",
 						},
 					},
 				},
 			},
 		}
-		err := ValidatePackageMetadata(md)
-		assert.Nil(t, err)
+		for i, tc := range testCases {
+			tc := tc
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				t.Parallel()
+				err := ValidatePackageMetadata(tc.kind, tc.md)
+				assert.Nil(t, err)
+			})
+		}
 	})
 }

--- a/internal/tracker/source/helm/helm.go
+++ b/internal/tracker/source/helm/helm.go
@@ -477,7 +477,7 @@ func EnrichPackageFromChart(p *hub.Package, chrt *chart.Chart) {
 		for _, imageRef := range imagesRefs {
 			containersImages = append(containersImages, &hub.ContainerImage{Image: imageRef})
 		}
-		if err := pkg.ValidateContainersImages(containersImages); err == nil {
+		if err := pkg.ValidateContainersImages(hub.Helm, containersImages); err == nil {
 			p.ContainersImages = containersImages
 		}
 	}
@@ -628,7 +628,7 @@ func EnrichPackageFromAnnotations(p *hub.Package, annotations map[string]string)
 		if err := yaml.Unmarshal([]byte(v), &images); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("%w: invalid images value", errInvalidAnnotation))
 		} else {
-			if err := pkg.ValidateContainersImages(images); err != nil {
+			if err := pkg.ValidateContainersImages(hub.Helm, images); err != nil {
 				errs = multierror.Append(errs, fmt.Errorf("%w: %s", errInvalidAnnotation, err.Error()))
 			} else {
 				p.ContainersImages = images

--- a/internal/tracker/source/helm/helm_test.go
+++ b/internal/tracker/source/helm/helm_test.go
@@ -722,7 +722,7 @@ func TestEnrichPackageFromAnnotations(t *testing.T) {
 `,
 			},
 			&hub.Package{},
-			"invalid container image: could not parse reference",
+			"invalid image reference: could not parse reference",
 		},
 		// License
 		{

--- a/internal/tracker/source/olm/olm.go
+++ b/internal/tracker/source/olm/olm.go
@@ -384,7 +384,7 @@ func PreparePackage(r *hub.Repository, md *Metadata) (*hub.Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := pkg.ValidateContainersImages(containersImages); err != nil {
+	if err := pkg.ValidateContainersImages(hub.OLM, containersImages); err != nil {
 		return nil, err
 	}
 	p.ContainersImages = containersImages

--- a/web/src/layout/package/installation/ContentInstall.module.css
+++ b/web/src/layout/package/installation/ContentInstall.module.css
@@ -46,6 +46,15 @@
   margin-bottom: 1rem;
 }
 
+.btnInLegend {
+  font-size: 80%;
+}
+
+.selectWrapper {
+  width: 30%;
+  min-width: 180px;
+}
+
 @media only screen and (max-width: 767.98px) {
   .blockWrapper {
     font-size: 0.9rem;

--- a/web/src/layout/package/installation/KubewardenInstall.test.tsx
+++ b/web/src/layout/package/installation/KubewardenInstall.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import KubewardenInstall from './KubewardenInstall';
+
+const defaultProps = {
+  name: 'kubewarden-repo',
+  images: [{ name: 'policy', image: 'ghcr.io/kubewarden/policies/...:vx.x.x' }],
+};
+
+describe('KubewardenInstall', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates snapshot', () => {
+    const { asFragment } = render(<KubewardenInstall {...defaultProps} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  describe('Render', () => {
+    it('renders component', () => {
+      render(<KubewardenInstall {...defaultProps} />);
+
+      expect(screen.getByText('kwctl pull ghcr.io/kubewarden/policies/...:vx.x.x')).toBeInTheDocument();
+      expect(screen.getByText(/The policy can be obtained using/)).toBeInTheDocument();
+
+      const link = screen.getByText('kwctl');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveProperty('href', 'https://github.com/kubewarden/kwctl/');
+    });
+
+    it('renders component with 2 images', async () => {
+      render(
+        <KubewardenInstall
+          {...defaultProps}
+          images={[
+            { name: 'policy', image: 'ghcr.io/kubewarden/policies/...:vx.x.x' },
+            { name: 'policy-alternative-location', image: 'ghcr.io/kubewarden/policies/...2:vx.x.x' },
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Source')).toBeInTheDocument();
+      expect(screen.getByText('kwctl pull ghcr.io/kubewarden/policies/...:vx.x.x')).toBeInTheDocument();
+
+      const select = screen.getByRole('combobox', { name: 'source-select' });
+      expect(select).toBeInTheDocument();
+      await userEvent.selectOptions(select, 'policy-alternative-location');
+
+      expect(await screen.findByText('kwctl pull ghcr.io/kubewarden/policies/...2:vx.x.x')).toBeInTheDocument();
+
+      const link = screen.getByText('kwctl');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveProperty('href', 'https://github.com/kubewarden/kwctl/');
+    });
+
+    it('renders private repo', () => {
+      render(<KubewardenInstall {...defaultProps} isPrivate />);
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent('Important: This repository is private and requires some credentials.');
+    });
+  });
+});

--- a/web/src/layout/package/installation/KubewardenInstall.tsx
+++ b/web/src/layout/package/installation/KubewardenInstall.tsx
@@ -1,0 +1,84 @@
+import { isNull, isUndefined, sortBy } from 'lodash';
+import { ChangeEvent, useState } from 'react';
+
+import { ContainerImage } from '../../../types';
+import ExternalLink from '../../common/ExternalLink';
+import CommandBlock from './CommandBlock';
+import styles from './ContentInstall.module.css';
+import PrivateRepoWarning from './PrivateRepoWarning';
+
+interface Props {
+  images: ContainerImage[] | null;
+  isPrivate?: boolean;
+}
+
+const DEFAULT_IMAGE = 'policy';
+
+interface Legend {
+  [key: string]: string;
+}
+
+const LEGENDS: Legend = {
+  policy: 'Primary location',
+  'policy-alternative-location': 'Alternative location',
+};
+
+const KubewardenInstall = (props: Props) => {
+  const [activeImage, setActiveImage] = useState<string>(DEFAULT_IMAGE);
+
+  const getActiveContainerImage = (name: string) => {
+    const img = props.images!.find((i: ContainerImage) => i.name === name);
+    return img!.image;
+  };
+
+  if (isNull(props.images)) return null;
+
+  const sortedImages = sortBy(props.images, 'name');
+
+  return (
+    <>
+      {props.images.length > 1 && (
+        <>
+          <div className="my-2">
+            <small className="text-muted mt-2 mb-1">Source</small>
+          </div>
+
+          <div className={styles.selectWrapper}>
+            <select
+              className="form-select form-select-sm mb-1"
+              aria-label="source-select"
+              value={activeImage}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => setActiveImage(e.target.value)}
+            >
+              {sortedImages.map((img: ContainerImage) => (
+                <option key={`image_${img.name}`} value={img.name}>
+                  {LEGENDS[img.name!]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      )}
+
+      <div className="my-2">
+        <div className="d-flex align-items-center mt-3 mb-1 text-muted">
+          <small>The policy can be obtained using</small>
+          <ExternalLink
+            href="https://github.com/kubewarden/kwctl/"
+            className={`btn btn-link p-0 ps-1 fw-bold ${styles.btnInLegend}`}
+            label="Download kwctl"
+          >
+            kwctl
+          </ExternalLink>
+          <small>:</small>
+        </div>
+      </div>
+
+      <CommandBlock command={`kwctl pull ${getActiveContainerImage(activeImage)}`} />
+
+      {!isUndefined(props.isPrivate) && props.isPrivate && <PrivateRepoWarning />}
+    </>
+  );
+};
+
+export default KubewardenInstall;

--- a/web/src/layout/package/installation/Modal.tsx
+++ b/web/src/layout/package/installation/Modal.tsx
@@ -19,6 +19,7 @@ import HelmInstall from './HelmInstall';
 import HelmOCIInstall from './HelmOCIInstall';
 import HelmPluginInstall from './HelmPluginInstall';
 import KrewInstall from './KrewInstall';
+import KubewardenInstall from './KubewardenInstall';
 import OLMInstall from './OLMInstall';
 import OLMOCIInstall from './OLMOCIInstall';
 import PublisherInstructionsInstall from './PublisherInstructionsInstall';
@@ -194,6 +195,10 @@ const InstallationModal = (props: Props) => {
                                 isPrivate={method.props.isPrivate}
                                 repository={method.props.repository!}
                               />
+                            );
+                          case InstallMethodKind.Kubewarden:
+                            return (
+                              <KubewardenInstall images={method.props.images!} isPrivate={method.props.isPrivate} />
                             );
                           default:
                             return null;

--- a/web/src/layout/package/installation/__snapshots__/KubewardenInstall.test.tsx.snap
+++ b/web/src/layout/package/installation/__snapshots__/KubewardenInstall.test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KubewardenInstall creates snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="my-2"
+  >
+    <div
+      class="d-flex align-items-center mt-3 mb-1 text-muted"
+    >
+      <small>
+        The policy can be obtained using
+      </small>
+      <a
+        aria-label="Download kwctl"
+        class="link btn btn-link p-0 ps-1 fw-bold btnInLegend"
+        href="https://github.com/kubewarden/kwctl/"
+        rel="noopener noreferrer"
+        role="button"
+        tabindex="-1"
+        target="_blank"
+      >
+        kwctl
+      </a>
+      <small>
+        :
+      </small>
+    </div>
+  </div>
+  <div
+    class="d-flex align-items-start"
+  >
+    <div
+      class="flex-grow-1 me-3 blockWrapper"
+    >
+      <pre
+        style="display: block; overflow-x: auto; padding: 0.5em; color: rgb(0, 0, 0); background: rgb(248, 248, 255);"
+      >
+        <code
+          class="language-bash"
+          style="white-space: pre;"
+        >
+          <span>
+            kwctl pull ghcr.io/kubewarden/policies/...:vx.x.x
+          </span>
+        </code>
+      </pre>
+    </div>
+    <div>
+      <div
+        class="position-relative undefined"
+      >
+        <button
+          aria-label="Copy command to clipboard"
+          class="btn btn-sm btn-primary rounded-circle copyBtn"
+          type="button"
+        >
+          <div
+            aria-hidden="true"
+            class="d-flex flex-row align-items-center"
+          >
+            <svg
+              fill="none"
+              height="1em"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                height="13"
+                rx="2"
+                ry="2"
+                width="13"
+                x="9"
+                y="9"
+              />
+              <path
+                d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+              />
+            </svg>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/utils/getInstallMethods.test.tsx
+++ b/web/src/utils/getInstallMethods.test.tsx
@@ -1,4 +1,4 @@
-import { HelmChartType, Package } from '../types';
+import { HelmChartType, Package, Signature } from '../types';
 import getInstallMethods, { InstallMethodOutput } from './getInstallMethods';
 
 interface Tests {
@@ -1336,6 +1336,304 @@ const tests: Tests[] = [
           subscriptions: 0,
           webhooks: 0,
         },
+      },
+    },
+    output: {
+      methods: [
+        {
+          label: 'publisher',
+          title: 'Publisher instructions',
+          kind: 0,
+          props: {
+            install: '###Custom install',
+          },
+        },
+      ],
+    },
+  },
+  {
+    title: 'Kubewarden policy with one image',
+    input: {
+      pkg: {
+        packageId: '72ce6bcb-f31b-40d0-8223-ffa191731e61',
+        name: 'allow-privilege-escalation-psp',
+        normalizedName: 'allow-privilege-escalation-psp',
+        isOperator: false,
+        displayName: 'Allow Privilege Escalation PSP',
+        description: 'A Pod Security Policy that controls usage of `allowPrivilegeEscalation`',
+        keywords: ['psp', 'container', 'privilege escalation'],
+        homeUrl: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+        readme:
+          '\n Continuous integration | License\n -----------------------|--------\n![Continuous integration](https://github.com/kubewarden/allow-privilege-escalation-psp-policy/workflows/Continuous%20integration/badge.svg) | [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)\n\nThis Kubewarden Policy is a replacement for the Kubernetes Pod Security Policy\nthat limits the usage of the [`allowPrivilegeEscalation`](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).\n\n# How the policy works\n\nThis policy rejects all the Pods that have at least one container or\ninit container with the `allowPrivilegeEscalation` security context\nenabled.\n\nThe policy can also mutate Pods to ensure they have `allowPrivilegeEscalation`\nset to `false` whenever the user is not explicit about that.\nThis is a replacement of the `DefaultAllowPrivilegeEscalation` configuration\noption of the original Kubernetes PSP.\n\n# Configuration\n\nThe policy can be configured in this way:\n\n```yaml\ndefault_allow_privilege_escalation: false\n```\n\nSets the default for the allowPrivilegeEscalation option. The default behavior without this is to allow privilege escalation so as to not break setuid binaries. If that behavior is not desired, this field can be used to default to disallow, while still permitting pods to request allowPrivilegeEscalation explicitly.\n\nBy default `default_allow_privilege_escalation` is set to `true`.\n\n# Examples\n\nThe following Pod will be rejected because the nginx container has\n`allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n    securityContext:\n      allowPrivilegeEscalation: true\n  - name: sidecar\n    image: sidecar\n```\n\nThe following Pod would be blocked because one of the init containers\nhas `allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n  - name: sidecar\n    image: sidecar\n  initContainers:\n  - name: init-myservice\n    image: init-myservice\n    securityContext:\n      allowPrivilegeEscalation: true\n```\n\n# Obtain policy\n\nThe policy is automatically published as an OCI artifact inside of\n[this](https://github.com/orgs/kubewarden/packages/container/package/policies%2Fpsp-allow-privilege-escalation)\ncontainer registry.\n\n# Using the policy\n\nThe easiest way to use this policy is through the [kubewarden-controller](https://github.com/kubewarden/kubewarden-controller).\n',
+        links: [
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.1.11/policy.wasm',
+            name: 'policy',
+          },
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+            name: 'source',
+          },
+        ],
+        data: {
+          kubewardenMutation: 'true',
+          kubewardenResources: 'Pod',
+        },
+        version: '0.1.11',
+        availableVersions: [
+          {
+            version: '0.1.11',
+            containsSecurityUpdates: false,
+            prerelease: false,
+            ts: 1658234781,
+          },
+        ],
+        deprecated: false,
+        containsSecurityUpdates: false,
+        prerelease: false,
+        license: 'Apache-2.0',
+        signed: true,
+        signatures: [Signature.Cosign],
+        containersImages: [
+          {
+            name: 'policy',
+            image: 'ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11',
+            whitelisted: false,
+          },
+        ],
+        allContainersImagesWhitelisted: false,
+        provider: 'kubewarden',
+        hasValuesSchema: false,
+        hasChangelog: false,
+        ts: 1658234781,
+        recommendations: [
+          {
+            url: 'https://artifacthub.io/packages/helm/kubewarden/kubewarden-controller',
+          },
+        ],
+        repository: {
+          repositoryId: '4a970f83-70af-45db-84a5-7439c85f28f4',
+          name: 'kube-test3',
+          url: 'https://github.com/cynthia-sg/allow-privilege-escalation-psp-policy',
+          private: false,
+          kind: 13,
+          verifiedPublisher: false,
+          official: false,
+          scannerDisabled: false,
+          userAlias: 'cynthia-sg',
+        },
+        stats: {
+          subscriptions: 0,
+          webhooks: 0,
+        },
+        productionOrganizationsCount: 0,
+      },
+    },
+    output: {
+      methods: [
+        {
+          label: 'kubewarden',
+          title: 'Kubewarden CLI',
+          kind: 9,
+          props: {
+            images: [
+              {
+                name: 'policy',
+                image: 'ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11',
+                whitelisted: false,
+              },
+            ],
+            isPrivate: false,
+          },
+        },
+      ],
+    },
+  },
+  {
+    title: 'Kubewarden policy with more than one image',
+    input: {
+      pkg: {
+        packageId: '72ce6bcb-f31b-40d0-8223-ffa191731e61',
+        name: 'allow-privilege-escalation-psp',
+        normalizedName: 'allow-privilege-escalation-psp',
+        isOperator: false,
+        displayName: 'Allow Privilege Escalation PSP',
+        description: 'A Pod Security Policy that controls usage of `allowPrivilegeEscalation`',
+        keywords: ['psp', 'container', 'privilege escalation'],
+        homeUrl: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+        readme:
+          '\n Continuous integration | License\n -----------------------|--------\n![Continuous integration](https://github.com/kubewarden/allow-privilege-escalation-psp-policy/workflows/Continuous%20integration/badge.svg) | [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)\n\nThis Kubewarden Policy is a replacement for the Kubernetes Pod Security Policy\nthat limits the usage of the [`allowPrivilegeEscalation`](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).\n\n# How the policy works\n\nThis policy rejects all the Pods that have at least one container or\ninit container with the `allowPrivilegeEscalation` security context\nenabled.\n\nThe policy can also mutate Pods to ensure they have `allowPrivilegeEscalation`\nset to `false` whenever the user is not explicit about that.\nThis is a replacement of the `DefaultAllowPrivilegeEscalation` configuration\noption of the original Kubernetes PSP.\n\n# Configuration\n\nThe policy can be configured in this way:\n\n```yaml\ndefault_allow_privilege_escalation: false\n```\n\nSets the default for the allowPrivilegeEscalation option. The default behavior without this is to allow privilege escalation so as to not break setuid binaries. If that behavior is not desired, this field can be used to default to disallow, while still permitting pods to request allowPrivilegeEscalation explicitly.\n\nBy default `default_allow_privilege_escalation` is set to `true`.\n\n# Examples\n\nThe following Pod will be rejected because the nginx container has\n`allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n    securityContext:\n      allowPrivilegeEscalation: true\n  - name: sidecar\n    image: sidecar\n```\n\nThe following Pod would be blocked because one of the init containers\nhas `allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n  - name: sidecar\n    image: sidecar\n  initContainers:\n  - name: init-myservice\n    image: init-myservice\n    securityContext:\n      allowPrivilegeEscalation: true\n```\n\n# Obtain policy\n\nThe policy is automatically published as an OCI artifact inside of\n[this](https://github.com/orgs/kubewarden/packages/container/package/policies%2Fpsp-allow-privilege-escalation)\ncontainer registry.\n\n# Using the policy\n\nThe easiest way to use this policy is through the [kubewarden-controller](https://github.com/kubewarden/kubewarden-controller).\n',
+        links: [
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.1.11/policy.wasm',
+            name: 'policy',
+          },
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+            name: 'source',
+          },
+        ],
+        data: {
+          kubewardenMutation: 'true',
+          kubewardenResources: 'Pod',
+        },
+        version: '0.1.11',
+        availableVersions: [
+          {
+            version: '0.1.11',
+            containsSecurityUpdates: false,
+            prerelease: false,
+            ts: 1658234781,
+          },
+        ],
+        deprecated: false,
+        containsSecurityUpdates: false,
+        prerelease: false,
+        license: 'Apache-2.0',
+        signed: true,
+        signatures: [Signature.Cosign],
+        containersImages: [
+          {
+            name: 'policy',
+            image: 'ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11',
+            whitelisted: false,
+          },
+          {
+            name: 'policy-alternative-location',
+            image: 'ghcr.io/xxx/policies/allow-privilege-escalation-psp:v0.1.11',
+            whitelisted: false,
+          },
+        ],
+        allContainersImagesWhitelisted: false,
+        provider: 'kubewarden',
+        hasValuesSchema: false,
+        hasChangelog: false,
+        ts: 1658234781,
+        recommendations: [
+          {
+            url: 'https://artifacthub.io/packages/helm/kubewarden/kubewarden-controller',
+          },
+        ],
+        repository: {
+          repositoryId: '4a970f83-70af-45db-84a5-7439c85f28f4',
+          name: 'kube-test3',
+          url: 'https://github.com/cynthia-sg/allow-privilege-escalation-psp-policy',
+          private: false,
+          kind: 13,
+          verifiedPublisher: false,
+          official: false,
+          scannerDisabled: false,
+          userAlias: 'cynthia-sg',
+        },
+        stats: {
+          subscriptions: 0,
+          webhooks: 0,
+        },
+        productionOrganizationsCount: 0,
+      },
+    },
+    output: {
+      methods: [
+        {
+          label: 'kubewarden',
+          title: 'Kubewarden CLI',
+          kind: 9,
+          props: {
+            images: [
+              {
+                name: 'policy',
+                image: 'ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11',
+                whitelisted: false,
+              },
+              {
+                name: 'policy-alternative-location',
+                image: 'ghcr.io/xxx/policies/allow-privilege-escalation-psp:v0.1.11',
+                whitelisted: false,
+              },
+            ],
+            isPrivate: false,
+          },
+        },
+      ],
+    },
+  },
+  {
+    title: 'Kubewarden policy with custom install instructions',
+    input: {
+      pkg: {
+        packageId: '72ce6bcb-f31b-40d0-8223-ffa191731e61',
+        name: 'allow-privilege-escalation-psp',
+        normalizedName: 'allow-privilege-escalation-psp',
+        isOperator: false,
+        displayName: 'Allow Privilege Escalation PSP',
+        description: 'A Pod Security Policy that controls usage of `allowPrivilegeEscalation`',
+        keywords: ['psp', 'container', 'privilege escalation'],
+        homeUrl: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+        readme:
+          '\n Continuous integration | License\n -----------------------|--------\n![Continuous integration](https://github.com/kubewarden/allow-privilege-escalation-psp-policy/workflows/Continuous%20integration/badge.svg) | [![License: Apache 2.0](https://img.shields.io/badge/License-Apache2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)\n\nThis Kubewarden Policy is a replacement for the Kubernetes Pod Security Policy\nthat limits the usage of the [`allowPrivilegeEscalation`](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).\n\n# How the policy works\n\nThis policy rejects all the Pods that have at least one container or\ninit container with the `allowPrivilegeEscalation` security context\nenabled.\n\nThe policy can also mutate Pods to ensure they have `allowPrivilegeEscalation`\nset to `false` whenever the user is not explicit about that.\nThis is a replacement of the `DefaultAllowPrivilegeEscalation` configuration\noption of the original Kubernetes PSP.\n\n# Configuration\n\nThe policy can be configured in this way:\n\n```yaml\ndefault_allow_privilege_escalation: false\n```\n\nSets the default for the allowPrivilegeEscalation option. The default behavior without this is to allow privilege escalation so as to not break setuid binaries. If that behavior is not desired, this field can be used to default to disallow, while still permitting pods to request allowPrivilegeEscalation explicitly.\n\nBy default `default_allow_privilege_escalation` is set to `true`.\n\n# Examples\n\nThe following Pod will be rejected because the nginx container has\n`allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n    securityContext:\n      allowPrivilegeEscalation: true\n  - name: sidecar\n    image: sidecar\n```\n\nThe following Pod would be blocked because one of the init containers\nhas `allowPrivilegeEscalation` enabled:\n\n```yaml\napiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\nspec:\n  containers:\n  - name: nginx\n    image: nginx\n  - name: sidecar\n    image: sidecar\n  initContainers:\n  - name: init-myservice\n    image: init-myservice\n    securityContext:\n      allowPrivilegeEscalation: true\n```\n\n# Obtain policy\n\nThe policy is automatically published as an OCI artifact inside of\n[this](https://github.com/orgs/kubewarden/packages/container/package/policies%2Fpsp-allow-privilege-escalation)\ncontainer registry.\n\n# Using the policy\n\nThe easiest way to use this policy is through the [kubewarden-controller](https://github.com/kubewarden/kubewarden-controller).\n',
+        links: [
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.1.11/policy.wasm',
+            name: 'policy',
+          },
+          {
+            url: 'https://github.com/kubewarden/allow-privilege-escalation-psp-policy',
+            name: 'source',
+          },
+        ],
+        data: {
+          kubewardenMutation: 'true',
+          kubewardenResources: 'Pod',
+        },
+        version: '0.1.11',
+        availableVersions: [
+          {
+            version: '0.1.11',
+            containsSecurityUpdates: false,
+            prerelease: false,
+            ts: 1658234781,
+          },
+        ],
+        install: '###Custom install',
+        deprecated: false,
+        containsSecurityUpdates: false,
+        prerelease: false,
+        license: 'Apache-2.0',
+        signed: true,
+        signatures: [Signature.Cosign],
+        containersImages: [
+          {
+            name: 'policy',
+            image: 'ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11',
+            whitelisted: false,
+          },
+        ],
+        allContainersImagesWhitelisted: false,
+        provider: 'kubewarden',
+        hasValuesSchema: false,
+        hasChangelog: false,
+        ts: 1658234781,
+        recommendations: [
+          {
+            url: 'https://artifacthub.io/packages/helm/kubewarden/kubewarden-controller',
+          },
+        ],
+        repository: {
+          repositoryId: '4a970f83-70af-45db-84a5-7439c85f28f4',
+          name: 'kube-test3',
+          url: 'https://github.com/cynthia-sg/allow-privilege-escalation-psp-policy',
+          private: false,
+          kind: 13,
+          verifiedPublisher: false,
+          official: false,
+          scannerDisabled: false,
+          userAlias: 'cynthia-sg',
+        },
+        stats: {
+          subscriptions: 0,
+          webhooks: 0,
+        },
+        productionOrganizationsCount: 0,
       },
     },
     output: {

--- a/web/src/utils/getInstallMethods.ts
+++ b/web/src/utils/getInstallMethods.ts
@@ -1,6 +1,6 @@
 import { isNull, isUndefined } from 'lodash';
 
-import { Channel, HelmChartType, Package, Repository, RepositoryKind } from '../types';
+import { Channel, ContainerImage, HelmChartType, Package, Repository, RepositoryKind } from '../types';
 import { OCI_PREFIX } from './data';
 
 export interface InstallMethod {
@@ -19,6 +19,7 @@ export interface InstallMethod {
     install?: string;
     isGlobalOperator?: boolean;
     isPrivate?: boolean;
+    images?: ContainerImage[] | null;
   };
 }
 
@@ -41,6 +42,7 @@ export enum InstallMethodKind {
   Krew,
   HelmPlugin,
   Tekton,
+  Kubewarden,
 }
 
 const SPECIAL_OLM = 'community-operators';
@@ -83,7 +85,6 @@ const getInstallMethods = (props: PackageInfo): InstallMethodOutput => {
         case RepositoryKind.KedaScaler:
         case RepositoryKind.CoreDNS:
         case RepositoryKind.Keptn:
-        case RepositoryKind.Kubewarden:
           if (isUndefined(pkg.install)) {
             output.errorMessage = 'This package does not include installation instructions yet.';
             hasError = true;
@@ -239,6 +240,19 @@ const getInstallMethods = (props: PackageInfo): InstallMethodOutput => {
             props: {
               contentUrl: pkg.contentUrl,
               repository: pkg.repository,
+              isPrivate: pkg.repository!.private,
+            },
+          });
+        }
+        break;
+      case RepositoryKind.Kubewarden:
+        if (isUndefined(pkg.install)) {
+          output.methods.push({
+            label: 'kubewarden',
+            title: 'Kubewarden CLI',
+            kind: InstallMethodKind.Kubewarden,
+            props: {
+              images: pkg.containersImages,
               isPrivate: pkg.repository!.private,
             },
           });


### PR DESCRIPTION
- Metadata validation
    - Kubewarden policies packages *must* provide at least one image in the metadata file, named `policy`
    - A second image, named `policy-alternative-location`, *can* be optionally provided
    - Listing more images or using unsupported names will raise an error
- A Kubewarden policy package will be considered signed when *all* images provided are signed
- The repositories guide has been updated to reflect the changes described above
- Provide default installation instructions based on the `policy` and `policy-alternative-location` images

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
Co-authored-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Co-authored-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>