### PR TITLE
Add dockerfile dependabot auto-update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,26 @@ updates:
     ignore:
       - dependency-name: "k8s.io/apimachinery"
       - dependency-name: "k8s.io/client-go"
+  - package-ecosystem: "docker"
+    directory: "/cmd/ah"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+  - package-ecosystem: "docker"
+    directory: "/cmd/hub"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+  - package-ecosystem: "docker"
+    directory: "/cmd/scanner"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+  - package-ecosystem: "docker"
+    directory: "/cmd/tracker"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Current container images containers critical vulnerabilities because base image have not been updated. 
Add dependabot to propose update to Dockerfile.