### PR TITLE
Auto-focus search form input field

### DIFF
--- a/web/src/layout/common/SearchBar.tsx
+++ b/web/src/layout/common/SearchBar.tsx
@@ -26,6 +26,7 @@ interface Props {
   isSearching: boolean;
   openTips: boolean;
   setOpenTips: (status: boolean) => void;
+  autoFocus?: boolean;
 }
 
 const SEARCH_DELAY = 3 * 100; // 300ms
@@ -249,6 +250,7 @@ const SearchBar = (props: Props) => {
             onChange={onChange}
             onKeyDown={onKeyDown}
             disabled={props.isSearching}
+            autoFocus={props.autoFocus}
           />
 
           <div className="d-none" tabIndex={0}>

--- a/web/src/layout/home/index.tsx
+++ b/web/src/layout/home/index.tsx
@@ -90,6 +90,7 @@ const HomeView = (props: Props) => {
             isSearching={props.isSearching}
             openTips={openTips}
             setOpenTips={setOpenTips}
+            autoFocus={true}
           />
           <SearchTipsModal size="big" openTips={openTips} setOpenTips={setOpenTips} />
           <SearchTip />

--- a/web/src/layout/navigation/LogIn.tsx
+++ b/web/src/layout/navigation/LogIn.tsx
@@ -268,6 +268,7 @@ const LogIn = (props: Props) => {
                   onChange={onEmailChange}
                   validateOnBlur={email !== ''}
                   required
+                  autoFocus={true}
                 />
 
                 <InputField


### PR DESCRIPTION
This sets the autoFocus attribute on the input field of the search form.
It does it only when the search form is displayed on the home page, not
on the search result page.

It also sets the autoFocus attribute on the Email field of the LogIn
Modal, for two reasons:

- convenience (field gets automatically focused when trying to log in)
- perhaps security (we're worried that the login modal might pop up
  spontaneously, for instance if the user's session expires, and the
  user might start typing their credentials while the search form is
  still selected)

Note: I haven't been able to test that latter behavior (I don't know
how to trigger the login modal to appear without also interacting
with the mouse, which would change the focus anyway...) so I don't
know if this is strictly necessary, but the convenience improvement
might be useful anyway.

Closes #1675.