### PR TITLE
[Helm Chart] Quality of life improvements

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.9.1-2
+version: 1.9.1-3
 appVersion: 1.9.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -102,3 +102,16 @@ env:
     value: "{{ .Values.db.user }}"
 command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
 {{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "chart.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "chart.tplvalues.render" -}}
+{{- if typeIs "string" .value }}
+  {{- tpl .value .context }}
+{{- else }}
+  {{- tpl (.value | toYaml) .context }}
+{{- end }}
+{{- end -}}

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -75,3 +75,13 @@ longest resource name ("db-migrator-install" = 19 chars).
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.hub.serviceAccount.create -}}
+  {{- .Values.hub.serviceAccount.name | default (printf "%s%s" (include "chart.resourceNamePrefix" .) "hub") -}}
+{{- else -}}
+  {{- .Values.hub.serviceAccount.name | default "default" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -85,3 +85,20 @@ Create the name of the service account to use
   {{- .Values.hub.serviceAccount.name | default "default" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Provide an init container to verify the database is accessible
+*/}}
+{{- define "chart.checkDbIsReadyInitContainer" -}}
+name: check-db-ready
+image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+imagePullPolicy: {{ .Values.pullPolicy }}
+env:
+  - name: PGHOST
+    value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
+  - name: PGPORT
+    value: "{{ .Values.db.port }}"
+  - name: PGUSER
+    value: "{{ .Values.db.user }}"
+command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+{{- end -}}

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -12,21 +12,21 @@ spec:
     {{- end }}
       restartPolicy: Never
       initContainers:
-      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
+        - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}
       containers:
-      - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        env:
-          - name: TERN_CONF
-            value: {{ .Values.dbMigrator.configDir }}/tern.conf
-        volumeMounts:
-          - name: db-migrator-config
-            mountPath: {{ .Values.dbMigrator.configDir }}
-            readOnly: true
-        command: ["./migrate.sh"]
+        - name: db-migrator
+          image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          env:
+            - name: TERN_CONF
+              value: {{ .Values.dbMigrator.configDir }}/tern.conf
+          volumeMounts:
+            - name: db-migrator-config
+              mountPath: {{ .Values.dbMigrator.configDir }}
+              readOnly: true
+          command: ["./migrate.sh"]
       volumes:
-      - name: db-migrator-config
-        secret:
-          secretName: {{ include "chart.resourceNamePrefix" . }}db-migrator-config
+        - name: db-migrator-config
+          secret:
+            secretName: {{ include "chart.resourceNamePrefix" . }}db-migrator-config
 {{- end }}

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -12,15 +12,7 @@ spec:
     {{- end }}
       restartPolicy: Never
       initContainers:
-      - name: check-db-ready
-        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        env:
-          - name: PGHOST
-            value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
-          - name: PGPORT
-            value: "{{ .Values.db.port }}"
-        command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
       containers:
       - name: db-migrator
         image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/artifact-hub/templates/db_migrator_secret.yaml
+++ b/charts/artifact-hub/templates/db_migrator_secret.yaml
@@ -11,6 +11,7 @@ stringData:
     database = {{ .Values.db.database }}
     user = {{ .Values.db.user }}
     password = {{ .Values.db.password }}
+    sslmode = {{ .Values.db.sslmode }}
 
     [data]
     loadSampleData = {{ .Values.dbMigrator.loadSampleData }}

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -15,20 +15,20 @@ spec:
     {{- end }}
       restartPolicy: Never
       initContainers:
-      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
+        - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}
       containers:
-      - name: db-migrator
-        image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        env:
-          - name: TERN_CONF
-            value: {{ .Values.dbMigrator.configDir }}/tern.conf
-        volumeMounts:
-          - name: db-migrator-config
-            mountPath: {{ .Values.dbMigrator.configDir }}
-            readOnly: true
-        command: ["./migrate.sh"]
+        - name: db-migrator
+          image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          env:
+            - name: TERN_CONF
+              value: {{ .Values.dbMigrator.configDir }}/tern.conf
+          volumeMounts:
+            - name: db-migrator-config
+              mountPath: {{ .Values.dbMigrator.configDir }}
+              readOnly: true
+          command: ["./migrate.sh"]
       volumes:
-      - name: db-migrator-config
-        secret:
-          secretName: {{ include "chart.resourceNamePrefix" . }}db-migrator-config
+        - name: db-migrator-config
+          secret:
+            secretName: {{ include "chart.resourceNamePrefix" . }}db-migrator-config

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -15,15 +15,7 @@ spec:
     {{- end }}
       restartPolicy: Never
       initContainers:
-      - name: check-db-ready
-        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        env:
-          - name: PGHOST
-            value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
-          - name: PGPORT
-            value: "{{ .Values.db.port }}"
-        command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
       containers:
       - name: db-migrator
         image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/artifact-hub/templates/extra-list.yaml
+++ b/charts/artifact-hub/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "chart.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -33,15 +33,7 @@ spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- end }}
       initContainers:
-      - name: check-db-ready
-        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        env:
-          - name: PGHOST
-            value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
-          - name: PGPORT
-            value: "{{ .Values.db.port }}"
-        command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
       {{- if .Release.IsInstall }}
       - name: check-db-migrator-run
         image: "bitnami/kubectl:{{ template "chart.KubernetesVersion" . }}"

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -36,7 +36,7 @@ spec:
       - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
       {{- if .Release.IsInstall }}
       - name: check-db-migrator-run
-        image: "bitnami/kubectl:{{ template "chart.KubernetesVersion" . }}"
+        image: "{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.repository }}:{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.tag | default (include "chart.KubernetesVersion" . ) }}"
         imagePullPolicy: IfNotPresent
         command: ['kubectl', 'wait', '--namespace={{ .Release.Namespace }}', '--for=condition=complete', 'job/{{ include "chart.resourceNamePrefix" . }}db-migrator-install', '--timeout=60s']
       {{- end }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       {{- if .Release.IsInstall }}
-      serviceAccountName: {{ include "chart.resourceNamePrefix" . }}hub
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- end }}
       initContainers:
       - name: check-db-ready

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -33,13 +33,13 @@ spec:
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- end }}
       initContainers:
-      - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 8 }}
-      {{- if .Release.IsInstall }}
-      - name: check-db-migrator-run
-        image: "{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.repository }}:{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.tag | default (include "chart.KubernetesVersion" . ) }}"
-        imagePullPolicy: IfNotPresent
-        command: ['kubectl', 'wait', '--namespace={{ .Release.Namespace }}', '--for=condition=complete', 'job/{{ include "chart.resourceNamePrefix" . }}db-migrator-install', '--timeout=60s']
-      {{- end }}
+        - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}
+        {{- if .Release.IsInstall }}
+        - name: check-db-migrator-run
+          image: "{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.repository }}:{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.tag | default (include "chart.KubernetesVersion" . ) }}"
+          imagePullPolicy: IfNotPresent
+          command: ['kubectl', 'wait', '--namespace={{ .Release.Namespace }}', '--for=condition=complete', 'job/{{ include "chart.resourceNamePrefix" . }}db-migrator-install', '--timeout=60s']
+        {{- end }}
       containers:
         - name: hub
           image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -50,13 +50,16 @@ spec:
               value: {{ .Values.hub.server.cacheDir | quote }}
           {{- end }}
           volumeMounts:
-          - name: hub-config
-            mountPath: {{ .Values.hub.server.configDir | quote }}
-            readOnly: true
-          {{- if .Values.hub.server.cacheDir }}
-          - name: cache-dir
-            mountPath: {{ .Values.hub.server.cacheDir | quote }}
-          {{- end }}
+            - name: hub-config
+              mountPath: {{ .Values.hub.server.configDir | quote }}
+              readOnly: true
+            {{- if .Values.hub.server.cacheDir }}
+            - name: cache-dir
+              mountPath: {{ .Values.hub.server.cacheDir | quote }}
+            {{- end }}
+            {{- if .Values.hub.deploy.extraVolumeMounts }}
+              {{- include "chart.tplvalues.render" (dict "value" .Values.hub.deploy.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8000
@@ -72,10 +75,13 @@ spec:
             {{- toYaml .Values.hub.deploy.readinessProbe | nindent 12}}
           {{- end }}
       volumes:
-      - name: hub-config
-        secret:
-          secretName: {{ include "chart.resourceNamePrefix" . }}hub-config
-      {{- if .Values.hub.server.cacheDir }}
-      - name: cache-dir
-        emptyDir: {}
-      {{- end }}
+        - name: hub-config
+          secret:
+            secretName: {{ include "chart.resourceNamePrefix" . }}hub-config
+        {{- if .Values.hub.server.cacheDir }}
+        - name: cache-dir
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.hub.deploy.extraVolumes }}
+          {{- include "chart.tplvalues.render" (dict "value" .Values.hub.deploy.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/artifact-hub/templates/hub_rbac.yaml
+++ b/charts/artifact-hub/templates/hub_rbac.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hub.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "chart.resourceNamePrefix" . }}job-reader
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "chart.resourceNamePrefix" . }}hub-job-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chart.resourceNamePrefix" . }}hub
+roleRef:
+  kind: Role
+  name: {{ include "chart.resourceNamePrefix" . }}job-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/artifact-hub/templates/hub_serviceaccount.yaml
+++ b/charts/artifact-hub/templates/hub_serviceaccount.yaml
@@ -1,25 +1,7 @@
+{{- if .Values.hub.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "chart.resourceNamePrefix" . }}hub
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "chart.resourceNamePrefix" . }}job-reader
-rules:
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "chart.resourceNamePrefix" . }}hub-job-reader
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "chart.resourceNamePrefix" . }}hub
-roleRef:
-  kind: Role
-  name: {{ include "chart.resourceNamePrefix" . }}job-reader
-  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "chart.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.hub.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
         {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
         {{- end }}
           restartPolicy: Never
           initContainers:

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -35,19 +35,25 @@ spec:
                 value: {{ .Values.scanner.cacheDir | quote }}
             {{- end }}
             volumeMounts:
+              - name: scanner-config
+                mountPath: {{ .Values.scanner.configDir | quote }}
+                readOnly: true
+              {{- if .Values.scanner.cacheDir }}
+              - name: cache-dir
+                mountPath: {{ .Values.scanner.cacheDir | quote }}
+              {{- end }}
+              {{- if .Values.scanner.cronjob.extraVolumeMounts }}
+                {{- include "chart.tplvalues.render" (dict "value" .Values.scanner.cronjob.extraVolumeMounts "context" $) | nindent 14 }}
+              {{- end }}
+          volumes:
             - name: scanner-config
-              mountPath: {{ .Values.scanner.configDir | quote }}
-              readOnly: true
+              secret:
+                secretName: {{ include "chart.resourceNamePrefix" . }}scanner-config
             {{- if .Values.scanner.cacheDir }}
             - name: cache-dir
-              mountPath: {{ .Values.scanner.cacheDir | quote }}
+              emptyDir: {}
             {{- end }}
-          volumes:
-          - name: scanner-config
-            secret:
-              secretName: {{ include "chart.resourceNamePrefix" . }}scanner-config
-          {{- if .Values.scanner.cacheDir }}
-          - name: cache-dir
-            emptyDir: {}
-          {{- end }}
+            {{- if .Values.scanner.cronjob.extraVolumes }}
+              {{- include "chart.tplvalues.render" (dict "value" .Values.scanner.cronjob.extraVolumes "context" $) | nindent 12 }}
+            {{- end }}
 {{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -22,15 +22,7 @@ spec:
         {{- end }}
           restartPolicy: Never
           initContainers:
-          - name: check-db-ready
-            image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-            imagePullPolicy: {{ .Values.pullPolicy }}
-            env:
-              - name: PGHOST
-                value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
-              - name: PGPORT
-                value: "{{ .Values.db.port }}"
-            command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+          - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 12 }}
           containers:
           - name: scanner
             image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scanner.enabled -}}
 {{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
 apiVersion: batch/v1
 {{- else }}
@@ -57,3 +58,4 @@ spec:
           - name: cache-dir
             emptyDir: {}
           {{- end }}
+{{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -22,29 +22,29 @@ spec:
         {{- end }}
           restartPolicy: Never
           initContainers:
-          - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 12 }}
+            - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}
           containers:
-          - name: scanner
-            image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
-            imagePullPolicy: {{ .Values.pullPolicy }}
-            resources:
-              {{- toYaml .Values.scanner.cronjob.resources | nindent 14 }}
-            {{- if .Values.scanner.cacheDir }}
-            env:
-              - name: TRIVY_CACHE_DIR
-                value: {{ .Values.scanner.cacheDir | quote }}
-            {{- end }}
-            volumeMounts:
-              - name: scanner-config
-                mountPath: {{ .Values.scanner.configDir | quote }}
-                readOnly: true
+            - name: scanner
+              image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+              imagePullPolicy: {{ .Values.pullPolicy }}
+              resources:
+                {{- toYaml .Values.scanner.cronjob.resources | nindent 16 }}
               {{- if .Values.scanner.cacheDir }}
-              - name: cache-dir
-                mountPath: {{ .Values.scanner.cacheDir | quote }}
+              env:
+                - name: TRIVY_CACHE_DIR
+                  value: {{ .Values.scanner.cacheDir | quote }}
               {{- end }}
-              {{- if .Values.scanner.cronjob.extraVolumeMounts }}
-                {{- include "chart.tplvalues.render" (dict "value" .Values.scanner.cronjob.extraVolumeMounts "context" $) | nindent 14 }}
-              {{- end }}
+              volumeMounts:
+                - name: scanner-config
+                  mountPath: {{ .Values.scanner.configDir | quote }}
+                  readOnly: true
+                {{- if .Values.scanner.cacheDir }}
+                - name: cache-dir
+                  mountPath: {{ .Values.scanner.cacheDir | quote }}
+                {{- end }}
+                {{- if .Values.scanner.cronjob.extraVolumeMounts }}
+                  {{- include "chart.tplvalues.render" (dict "value" .Values.scanner.cronjob.extraVolumeMounts "context" $) | nindent 16 }}
+                {{- end }}
           volumes:
             - name: scanner-config
               secret:

--- a/charts/artifact-hub/templates/scanner_secret.yaml
+++ b/charts/artifact-hub/templates/scanner_secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.scanner.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,3 +24,4 @@ stringData:
     scanner:
       concurrency: {{ .Values.scanner.concurrency }}
       trivyURL: {{ .Values.scanner.trivyURL | default (printf "http://%s%s:8081" (include "chart.resourceNamePrefix" .) "trivy") }}
+{{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -21,15 +21,7 @@ spec:
         {{- end }}
           restartPolicy: Never
           initContainers:
-          - name: check-db-ready
-            image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-            imagePullPolicy: {{ .Values.pullPolicy }}
-            env:
-              - name: PGHOST
-                value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
-              - name: PGPORT
-                value: "{{ .Values.db.port }}"
-            command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+          - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 12 }}
           containers:
           - name: tracker
             image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -34,18 +34,24 @@ spec:
                 value: {{ .Values.tracker.cacheDir | quote }}
             {{- end }}
             volumeMounts:
+              - name: tracker-config
+                mountPath: {{ .Values.tracker.configDir | quote }}
+                readOnly: true
+              {{- if .Values.tracker.cacheDir }}
+              - name: cache-dir
+                mountPath: {{ .Values.tracker.cacheDir | quote }}
+              {{- end }}
+              {{- if .Values.tracker.cronjob.extraVolumeMounts }}
+                {{- include "chart.tplvalues.render" (dict "value" .Values.tracker.cronjob.extraVolumeMounts "context" $) | nindent 14 }}
+              {{- end }}
+          volumes:
             - name: tracker-config
-              mountPath: {{ .Values.tracker.configDir | quote }}
-              readOnly: true
+              secret:
+                secretName: {{ include "chart.resourceNamePrefix" . }}tracker-config
             {{- if .Values.tracker.cacheDir }}
             - name: cache-dir
-              mountPath: {{ .Values.tracker.cacheDir | quote }}
+              emptyDir: {}
             {{- end }}
-          volumes:
-          - name: tracker-config
-            secret:
-              secretName: {{ include "chart.resourceNamePrefix" . }}tracker-config
-          {{- if .Values.tracker.cacheDir }}
-          - name: cache-dir
-            emptyDir: {}
-          {{- end }}
+            {{- if .Values.tracker.cronjob.extraVolumes }}
+              {{- include "chart.tplvalues.render" (dict "value" .Values.tracker.cronjob.extraVolumes "context" $) | nindent 12 }}
+            {{- end }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -21,29 +21,29 @@ spec:
         {{- end }}
           restartPolicy: Never
           initContainers:
-          - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 12 }}
+            - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}
           containers:
-          - name: tracker
-            image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
-            imagePullPolicy: {{ .Values.pullPolicy }}
-            resources:
-              {{- toYaml .Values.tracker.cronjob.resources | nindent 14 }}
-            {{- if .Values.tracker.cacheDir }}
-            env:
-              - name: XDG_CACHE_HOME
-                value: {{ .Values.tracker.cacheDir | quote }}
-            {{- end }}
-            volumeMounts:
-              - name: tracker-config
-                mountPath: {{ .Values.tracker.configDir | quote }}
-                readOnly: true
+            - name: tracker
+              image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+              imagePullPolicy: {{ .Values.pullPolicy }}
+              resources:
+                {{- toYaml .Values.tracker.cronjob.resources | nindent 16 }}
               {{- if .Values.tracker.cacheDir }}
-              - name: cache-dir
-                mountPath: {{ .Values.tracker.cacheDir | quote }}
+              env:
+                - name: XDG_CACHE_HOME
+                  value: {{ .Values.tracker.cacheDir | quote }}
               {{- end }}
-              {{- if .Values.tracker.cronjob.extraVolumeMounts }}
-                {{- include "chart.tplvalues.render" (dict "value" .Values.tracker.cronjob.extraVolumeMounts "context" $) | nindent 14 }}
-              {{- end }}
+              volumeMounts:
+                - name: tracker-config
+                  mountPath: {{ .Values.tracker.configDir | quote }}
+                  readOnly: true
+                {{- if .Values.tracker.cacheDir }}
+                - name: cache-dir
+                  mountPath: {{ .Values.tracker.cacheDir | quote }}
+                {{- end }}
+                {{- if .Values.tracker.cronjob.extraVolumeMounts }}
+                  {{- include "chart.tplvalues.render" (dict "value" .Values.tracker.cronjob.extraVolumeMounts "context" $) | nindent 16 }}
+                {{- end }}
           volumes:
             - name: tracker-config
               secret:

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -31,9 +31,9 @@ spec:
               {{- include "chart.tplvalues.render" (dict "value" .Values.trivy.deploy.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           ports:
-          - name: http
-            containerPort: 8081
-            protocol: TCP
+            - name: http
+              containerPort: 8081
+              protocol: TCP
           resources:
             {{- toYaml .Values.trivy.deploy.resources | nindent 12 }}
       volumes:

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -25,8 +25,11 @@ spec:
           image: {{ .Values.trivy.deploy.image }}
           command: ['trivy', '--debug', '--cache-dir', '/trivy', 'server', '--listen', '0.0.0.0:8081']
           volumeMounts:
-          - name: trivy
-            mountPath: "/trivy"
+            - name: trivy
+              mountPath: "/trivy"
+            {{- if .Values.trivy.deploy.extraVolumeMounts }}
+              {{- include "chart.tplvalues.render" (dict "value" .Values.trivy.deploy.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           ports:
           - name: http
             containerPort: 8081
@@ -34,11 +37,14 @@ spec:
           resources:
             {{- toYaml .Values.trivy.deploy.resources | nindent 12 }}
       volumes:
-      - name: trivy
-      {{- if .Values.trivy.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ include "chart.resourceNamePrefix" . }}trivy
-      {{- else }}
-        emptyDir: {}
-      {{- end -}}
+        - name: trivy
+        {{- if .Values.trivy.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "chart.resourceNamePrefix" . }}trivy
+        {{- else }}
+          emptyDir: {}
+        {{- end -}}
+        {{- if .Values.trivy.deploy.extraVolumes }}
+          {{- include "chart.tplvalues.render" (dict "value" .Values.trivy.deploy.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.trivy.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,3 +41,4 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end -}}
+{{- end }}

--- a/charts/artifact-hub/templates/trivy_pvc.yaml
+++ b/charts/artifact-hub/templates/trivy_pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.trivy.persistence.enabled }}
+{{- if .Values.trivy.enabled | and .Values.trivy.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/artifact-hub/templates/trivy_service.yaml
+++ b/charts/artifact-hub/templates/trivy_service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.trivy.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
   selector:
     app.kubernetes.io/component: trivy
     {{- include "chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -221,6 +221,35 @@
                                 "repository"
                             ]
                         },
+                        "initContainers": {
+                            "title": "Init containers",
+                            "type": "object",
+                            "properties": {
+                                "checkDbMigrator": {
+                                    "title": "Check DB migrator",
+                                    "type": "object",
+                                    "properties": {
+                                        "image": {
+                                            "title": "image",
+                                            "type": "object",
+                                            "properties": {
+                                                "repository": {
+                                                    "title": "Check DB migrator repository",
+                                                    "type": "string",
+                                                    "default": "bitnami/kubectl"
+                                                },
+                                                "tag": {
+                                                    "title": "Check DB migrator tag",
+                                                    "description": "Tag used when pulling check-db-migrator initContainer image. Defaults to the K8s API version",
+                                                    "type": "string",
+                                                    "default": ""
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         "livenessProbe": {
                             "title": "Hub pod liveness probe",
                             "type": "object",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -42,6 +42,12 @@
                     "default": "5432",
                     "type": "string"
                 },
+                "sslmode": {
+                    "title": "Database SSL mode",
+                    "description": "Sets SSL mode if supported by db client",
+                    "default": "prefer",
+                    "type": "string"
+                },
                 "user": {
                     "title": "Database user",
                     "default": "postgres",
@@ -53,6 +59,7 @@
                 "host",
                 "password",
                 "port",
+                "sslmode",
                 "user"
             ]
         },

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -191,6 +191,12 @@
                 "trackingErrors"
             ]
         },
+        "extraDeploy": {
+            "title": "Extra deploy objects",
+            "description": "Extra objects to deploy (value evaluated as a template)",
+            "type": "array",
+            "default": "[]"
+        },
         "hub": {
             "title": "Hub configuration",
             "type": "object",

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -304,6 +304,21 @@
                         "enabled"
                     ]
                 },
+                "rbac": {
+                    "title": "RBAC",
+                    "type":"object",
+                    "properties": {
+                        "create": {
+                            "title": "Create RBAC",
+                            "description": "Enable creation and role and role binding",
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    "required": [
+                        "create"
+                    ]
+                },
                 "server": {
                     "type": "object",
                     "properties": {
@@ -578,6 +593,34 @@
                         "type"
                     ]
                 },
+                "serviceAccount": {
+                    "title": "Artifact Hub service account",
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "title": "Create service account",
+                            "description": "Enables the creation of a ServiceAccount for the Artifact Hub pod",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "name": {
+                            "title": "Service account name",
+                            "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "automountServiceAccountToken": {
+                            "title": "Automount service account token",
+                            "description": "Allows auto mount of the ServiceAccountToken on the servicea account created",
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    "required": [
+                        "create",
+                        "automountServiceAccountToken"
+                    ]
+                },
                 "theme": {
                     "type": "object",
                     "properties": {
@@ -675,9 +718,11 @@
                 }
             },
             "required": [
-                "ingress",
-                "service",
                 "deploy",
+                "ingress",
+                "rbac",
+                "service",
+                "serviceAccount",
                 "server",
                 "theme"
             ]

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -804,10 +804,15 @@
                         "resources"
                     ]
                 },
+                "enabled": {
+                    "title": "Enable security scanner cronjob",
+                    "type": "boolean",
+                    "default": true
+                },
                 "trivyURL": {
                     "title": "Trivy server url",
                     "type": "string",
-                    "description": "Defaults to the Trivy service's internal URL.",
+                    "description": "Defaults to the Trivy service's internal URL. If Trivy is not enabled via this chart, the URL must be set to an external Trivy service.",
                     "default": ""
                 }
             },
@@ -815,6 +820,7 @@
                 "concurrency",
                 "configDir",
                 "cronjob",
+                "enabled",
                 "trivyURL"
             ]
         },
@@ -916,6 +922,12 @@
             "title": "Trivy configuration",
             "type": "object",
             "properties": {
+                "enabled": {
+                    "title": "Enable Trivy security scanner deployment",
+                    "description": "If the Trivy security scanner deployment is disabled while the scanner cronJob is enabled, Trivy must be deployed separately from this chart. Use `scanner.trivyURL` to reference the separate Trivy instance.",
+                    "type": "boolean",
+                    "default": true
+                },
                 "deploy": {
                     "type": "object",
                     "properties": {
@@ -962,6 +974,7 @@
             },
             "required": [
                 "deploy",
+                "enabled",
                 "persistence"
             ]
         }

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -214,6 +214,18 @@
                 "deploy": {
                     "type": "object",
                     "properties": {
+                        "extraVolumes": {
+                            "title": "Extra volumes",
+                            "description": "Optionally specify extra list of additional volumes for the hub deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraVolumeMounts": {
+                            "title": "Extra volume mounts",
+                            "description": "Optionally specify extra list of additional volume mounts for the hub deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -859,6 +871,18 @@
                 "cronjob": {
                     "type": "object",
                     "properties": {
+                        "extraVolumes": {
+                            "title": "Extra volumes",
+                            "description": "Optionally specify extra list of additional volumes for the scanner cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraVolumeMounts": {
+                            "title": "Extra volume mounts",
+                            "description": "Optionally specify extra list of additional volume mounts for the scanner cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -938,6 +962,18 @@
                 "cronjob": {
                     "type": "object",
                     "properties": {
+                        "extraVolumes": {
+                            "title": "Extra volumes",
+                            "description": "Optionally specify extra list of additional volumes for the tracker cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraVolumeMounts": {
+                            "title": "Extra volume mounts",
+                            "description": "Optionally specify extra list of additional volume mounts for the tracker cronjob",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {
@@ -1011,6 +1047,18 @@
                 "deploy": {
                     "type": "object",
                     "properties": {
+                        "extraVolumes": {
+                            "title": "Extra volumes",
+                            "description": "Optionally specify extra list of additional volumes for the trivy deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
+                        "extraVolumeMounts": {
+                            "title": "Extra volume mounts",
+                            "description": "Optionally specify extra list of additional volume mounts for the trivy deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "title": "Trivy container image",
                             "type": "string",

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -224,6 +224,7 @@ hub:
 
 # Scanner configuration
 scanner:
+  enabled: true
   cronjob:
     image:
       # Scanner image repository (without the tag)
@@ -264,6 +265,7 @@ tracker:
 
 # Trivy configuration
 trivy:
+  enabled: true
   deploy:
     image: aquasec/trivy:0.31.3
     resources: {}

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -100,6 +100,18 @@ hub:
   service:
     type: NodePort
     port: 80
+  # Service account for Artifact Hub to use
+  serviceAccount:
+    # Enable creation of ServiceAccount for Artifact Hub pod
+    create: true
+    # The name of the ServiceAccount to use. If not set and create is true, a name is generated
+    name: ""
+    # Allows auto mount of ServiceAccountToken on the serviceAccount created
+    automountServiceAccountToken: true
+  # Create and bind role for service account
+  rbac:
+    # Enable creation and binding of role
+    create: true
   deploy:
     readinessGates: []
     replicaCount: 1

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -37,6 +37,7 @@ db:
   database: hub
   user: postgres
   password: postgres
+  sslmode: prefer
 
 # Email configuration
 email:

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -302,3 +302,6 @@ postgresql:
   postgresqlPassword: postgres
   postgresqlDatabase: hub
   postgresqlDataDir: /data/pgdata
+
+# Extra objects to deploy (value evaluated as a template)
+extraDeploy: []

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -124,6 +124,10 @@ hub:
         image:
           repository: bitnami/kubectl
           # tag: 1.21
+    # Optionally specify extra list of additional volumes for the hub deployment
+    extraVolumes: []
+    # Optionally specify extra list of additional volume mounts for the hub deployment
+    extraVolumeMounts: []
   server:
     # Allow adding private repositories to the Hub
     allowPrivateRepositories: false
@@ -247,6 +251,10 @@ scanner:
       # Scanner image repository (without the tag)
       repository: artifacthub/scanner
     resources: {}
+    # Optionally specify extra list of additional volumes for the scanner cronjob
+    extraVolumes: []
+    # Optionally specify extra list of additional volume mounts for the scanner cronjob
+    extraVolumeMounts: []
   # Number of snapshots to process concurrently
   concurrency: 3
   # Trivy server url. Defaults to the Trivy service's internal URL
@@ -264,6 +272,10 @@ tracker:
       # Tracker image repository (without the tag)
       repository: artifacthub/tracker
     resources: {}
+    # Optionally specify extra list of additional volumes for the tracker cronjob
+    extraVolumes: []
+    # Optionally specify extra list of additional volume mounts for the tracker cronjob
+    extraVolumeMounts: []
   # Cache directory path. If set, the cache directory for the Helm client will be explicitly set (otherwise defaults
   # to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir)
   cacheDir: ""
@@ -286,6 +298,10 @@ trivy:
   deploy:
     image: aquasec/trivy:0.31.3
     resources: {}
+    # Optionally specify extra list of additional volumes for the trivy deployment
+    extraVolumes: []
+    # Optionally specify extra list of additional volume mounts for the trivy deployment
+    extraVolumeMounts: []
   persistence:
     enabled: false
     size: 10Gi

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -119,6 +119,11 @@ hub:
       # Hub image repository (without the tag)
       repository: artifacthub/hub
     resources: {}
+    initContainers:
+      checkDbMigrator:
+        image:
+          repository: bitnami/kubectl
+          # tag: 1.21
   server:
     # Allow adding private repositories to the Hub
     allowPrivateRepositories: false


### PR DESCRIPTION
I am currently trying to run a self-hosted Artifact Hub instance on a self-hosted K8s environment. Due to the security constraints of my self-host K8s environment, I need the deployment via helm chart to be more customizable. Therefor this pull request contains the following changes:

- Option to enable/disable the trivy scanner (enabled by default)
- Option to enable/disable RBAC resources (enabled by default)
- Option(s) to set `securityContext` on diverse workloads
- Option to mount custom volumes (e.g. to inject root certificates for self-signed certificates)
- Option to provide extra manifests (e.g. to deploy a configMap containing an additional root certificate)
- Option to set [PostgreSQL ssl mode](https://www.postgresql.org/docs/9.4/libpq-ssl.html#LIBPQ-SSL-PROTECTION) in tern config for db-migrator job(s).

Unless you have any concerns, I would continue to add the afore mentioned functionality in the next working days...