### PR TITLE
Helm: add missing resource definitions and resort to curly braces as default

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.9.1-6
+version: 1.9.1-7
 appVersion: 1.9.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -93,11 +93,9 @@ Provide an init container to verify the database is accessible
 name: check-db-ready
 image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
 imagePullPolicy: {{ .Values.pullPolicy }}
-{{- if .Values.hub.deploy.initContainers.checkDbIsReady }}
 {{- with .Values.hub.deploy.initContainers.checkDbIsReady.resources }}
 resources:
   {{-  toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}
 env:
   - name: PGHOST

--- a/charts/artifact-hub/templates/db_migrator_install_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_install_job.yaml
@@ -17,6 +17,10 @@ spec:
         - name: db-migrator
           image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- with .Values.dbMigrator.job.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: TERN_CONF
               value: {{ .Values.dbMigrator.configDir }}/tern.conf

--- a/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_upgrade_job.yaml
@@ -20,6 +20,10 @@ spec:
         - name: db-migrator
           image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- with .Values.dbMigrator.job.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: TERN_CONF
               value: {{ .Values.dbMigrator.configDir }}/tern.conf

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -84,6 +84,12 @@
                             ]
                         }
                     },
+                    "resources": {
+                        "title": "DB migrator pod resource requirements",
+                        "type": "object",
+                        "default": {},
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                    },
                     "required": [
                         "image"
                     ]

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -85,6 +85,15 @@ dbMigrator:
     image:
       # Database migrator image repository (without the tag)
       repository: artifacthub/db-migrator
+    resources: {}
+    # If you do want to specify resources, uncomment the following
+    # lines and adjust them as necessary.
+    #   limits:
+    #     cpu: 100m
+    #     memory: 128Mi
+    #   requests:
+    #     cpu: 100m
+    #     memory: 128Mi
   # Load demo user and sample repositories
   loadSampleData: true
   # Directory path where the configuration files should be mounted
@@ -119,9 +128,9 @@ hub:
     image:
       # Hub image repository (without the tag)
       repository: artifacthub/hub
+    resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
-    # resources:
     #   limits:
     #     cpu: 100m
     #     memory: 128Mi
@@ -133,9 +142,9 @@ hub:
         image:
           repository: bitnami/kubectl
           # tag: 1.21
+        resources: {}
         # If you do want to specify resources, uncomment the following
         # lines and adjust them as necessary.
-        # resources:
         #   limits:
         #     cpu: 100m
         #     memory: 128Mi
@@ -143,9 +152,9 @@ hub:
         #     cpu: 100m
         #     memory: 128Mi
       checkDbIsReady:
+        resources: {}
         # If you do want to specify resources, uncomment the following
         # lines and adjust them as necessary.
-        # resources:
         #   limits:
         #     cpu: 100m
         #     memory: 128Mi
@@ -278,9 +287,9 @@ scanner:
     image:
       # Scanner image repository (without the tag)
       repository: artifacthub/scanner
+    resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
-    # resources:
     #   limits:
     #     cpu: 100m
     #     memory: 128Mi
@@ -307,9 +316,9 @@ tracker:
     image:
       # Tracker image repository (without the tag)
       repository: artifacthub/tracker
+    resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
-    # resources:
     #   limits:
     #     cpu: 100m
     #     memory: 128Mi
@@ -341,9 +350,9 @@ trivy:
   enabled: true
   deploy:
     image: aquasec/trivy:0.31.3
+    resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
-    # resources:
     #   limits:
     #     cpu: 100m
     #     memory: 128Mi


### PR DESCRIPTION
This PR add resource definitions to the last remaining containers. I also went back to having empty resources as default value (curly braces) since my linter otherwise throws errors for using non-existent values in the templates.

Signed-off-by: Carsten Heidmann <carsten.heidmann@disy.net>