### PR TITLE
Process Tekton Signature and Show "Signed" Badge

### DIFF
--- a/internal/tracker/source/tekton/tekton.go
+++ b/internal/tracker/source/tekton/tekton.go
@@ -66,9 +66,13 @@ const (
 	providerAnnotation        = "artifacthub.io/provider"
 	recommendationsAnnotation = "artifacthub.io/recommendations"
 	screenshotsAnnotation     = "artifacthub.io/screenshots"
+	signatureAnnotation       = "tekton.dev/signature"
 
 	// examplesPath defines the location of the examples in the package's path.
 	examplesPath = "samples"
+
+	// tekton represents the tekton signature kind.
+	tekton = "tekton"
 )
 
 var (
@@ -550,6 +554,17 @@ func enrichPackageFromAnnotations(p *hub.Package, annotations map[string]string)
 			errs = multierror.Append(errs, fmt.Errorf("%w: invalid screenshots value", errInvalidAnnotation))
 		} else {
 			p.Screenshots = screenshots
+		}
+	}
+
+	// Sign key
+	if v, ok := annotations[signatureAnnotation]; ok {
+		var signature string
+		if err := yaml.Unmarshal([]byte(v), &signature); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("%w: invalid signature value", errInvalidAnnotation))
+		} else if signature != "" {
+			p.Signatures = []string{tekton}
+			p.Signed = true
 		}
 	}
 

--- a/internal/tracker/source/tekton/tekton_test.go
+++ b/internal/tracker/source/tekton/tekton_test.go
@@ -84,7 +84,7 @@ func TestTrackerSource(t *testing.T) {
 			Version:     "0.1.0",
 			Provider:    "Some organization",
 			ContentURL:  "https://github.com/user/repo/raw/master/path/task1/0.1/task1.yaml",
-			Digest:      "d5ef3fb05c34644e5ba4fd5a5c3db13be13c11606e663f8583438c2a9d6d243f",
+			Digest:      "02bac9928e46c44079c259cd6d04adfd2b9f3bcf5c854f92fb80de4e4b4595fd",
 			Repository:  i.Repository,
 			License:     "Apache-2.0",
 			Links: []*hub.Link{
@@ -139,6 +139,8 @@ func TestTrackerSource(t *testing.T) {
 					"sample1.yaml": "sample content\n",
 				},
 			},
+			Signatures: []string{tekton},
+			Signed:     true,
 		}
 		packages, err := NewTrackerSource(i).GetPackagesAvailable()
 		assert.Equal(t, map[string]*hub.Package{
@@ -174,7 +176,7 @@ func TestTrackerSource(t *testing.T) {
 			Version:     "0.1.0",
 			Provider:    "Some organization",
 			ContentURL:  "https://github.com/user/repo/raw/master/path/pipeline1/0.1/pipeline1.yaml",
-			Digest:      "42ca2266946a1bedec7eb5a9f1045ba92ff81f3f65b097aab085e1cc22554755",
+			Digest:      "c871546c7f4ae01c2611b828a7eaba60461a555d8e24ad84a1c553d1af52beee",
 			Repository:  i.Repository,
 			License:     "Apache-2.0",
 			Links: []*hub.Link{
@@ -242,6 +244,8 @@ func TestTrackerSource(t *testing.T) {
 					"sample1.yaml": "sample content\n",
 				},
 			},
+			Signatures: []string{tekton},
+			Signed:     true,
 		}
 		packages, err := NewTrackerSource(i).GetPackagesAvailable()
 		assert.Equal(t, map[string]*hub.Package{

--- a/internal/tracker/source/tekton/testdata/path3/task1/0.1/task1.yaml
+++ b/internal/tracker/source/tekton/testdata/path3/task1/0.1/task1.yaml
@@ -29,5 +29,6 @@ metadata:
     tekton.dev/platforms: "linux/amd64, linux/arm64"
     tekton.dev/tags: tag1, tag2
     tekton.dev/displayName: "Task 1"
+    tekton.dev/signature: "task signature val"
 spec:
   description: Test task

--- a/internal/tracker/source/tekton/testdata/path4/pipeline1/0.1/pipeline1.yaml
+++ b/internal/tracker/source/tekton/testdata/path4/pipeline1/0.1/pipeline1.yaml
@@ -29,6 +29,7 @@ metadata:
     tekton.dev/platforms: "linux/amd64,linux/arm64"
     tekton.dev/tags: tag1, tag2
     tekton.dev/displayName: "Pipeline 1"
+    tekton.dev/signature: "pipeline signature val"
 spec:
   description: Test pipeline
   tasks:


### PR DESCRIPTION
The [Tekton Trusted Resources](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md#sign-the-resources) feature introduces digital signatures (stored in `tekton.dev/signature` annotation) for Tekton resources. This commit parses the new signature annotation and show a "Signed" badge for Tekton resources with such annotation.

Signed-off-by: Quan Zhang <zhangquan@google.com>