### PR TITLE
Introduce package alternative name concept

### DIFF
--- a/database/migrations/functions/packages/generate_package_tsdoc.sql
+++ b/database/migrations/functions/packages/generate_package_tsdoc.sql
@@ -2,6 +2,7 @@
 -- text searches.
 create or replace function generate_package_tsdoc(
     p_name text,
+    p_alternative_name text,
     p_display_name text,
     p_description text,
     p_keywords text[],
@@ -10,6 +11,7 @@ create or replace function generate_package_tsdoc(
 ) returns tsvector as $$
     select
         setweight(to_tsvector(p_name), 'A') ||
+        setweight(to_tsvector(coalesce(p_alternative_name, '')), 'A') ||
         setweight(to_tsvector(coalesce(p_display_name, '')), 'A') ||
         setweight(to_tsvector(coalesce(p_description, '')), 'B') ||
         setweight(to_tsvector(array_to_string(coalesce(p_keywords, '{}'), ' ')), 'C') ||

--- a/database/migrations/functions/repositories/transfer_repository.sql
+++ b/database/migrations/functions/repositories/transfer_repository.sql
@@ -72,6 +72,7 @@ begin
             p.package_id,
             generate_package_tsdoc(
                 p.name,
+                p.alternative_name,
                 s.display_name,
                 s.description,
                 s.keywords,

--- a/database/migrations/schema/042_package_alternative_name.sql
+++ b/database/migrations/schema/042_package_alternative_name.sql
@@ -1,0 +1,5 @@
+alter table package add column alternative_name text;
+
+---- create above / drop below ----
+
+alter table package drop column alternative_name;

--- a/database/tests/functions/packages/register_package.sql
+++ b/database/tests/functions/packages/register_package.sql
@@ -18,6 +18,7 @@ values (:'repo1ID', 'repo1', 'Repo 1', 'https://repo1.com', 0, :'org1ID');
 select register_package('
 {
     "name": "package1",
+    "alternative_name": "mypackage1",
     "logo_url": "logo_url",
     "logo_image_id": "00000000-0000-0000-0000-000000000001",
     "channels": [
@@ -124,6 +125,7 @@ select results_eq(
     $$
         select
             name,
+            alternative_name,
             latest_version,
             is_operator,
             channels,
@@ -135,6 +137,7 @@ select results_eq(
     $$
         values (
             'package1',
+            'mypackage1',
             '1.0.0',
             true,
             '[
@@ -272,6 +275,7 @@ select is_empty(
 select register_package('
 {
     "name": "package1",
+    "alternative_name": "mypackage1",
     "logo_url": "logo_url",
     "logo_image_id": "00000000-0000-0000-0000-000000000001",
     "display_name": "Package 1 v2",
@@ -415,6 +419,7 @@ select isnt_empty(
 select register_package('
 {
     "name": "package1",
+    "alternative_name": "mypackage1",
     "display_name": "Package 1",
     "description": "description",
     "logo_url": "logo_url",

--- a/database/tests/functions/packages/search_packages.sql
+++ b/database/tests/functions/packages/search_packages.sql
@@ -58,7 +58,7 @@ insert into package (
     '1.0.0',
     true,
     10,
-    generate_package_tsdoc('package1', null, 'description', '{"kw1", "kw1", "kw2"}', '{"repo1"}', '{"user1"}'),
+    generate_package_tsdoc('package1', null, null, 'description', '{"kw1", "kw1", "kw2"}', '{"repo1"}', '{"user1"}'),
     false,
     :'repo1ID'
 );
@@ -129,7 +129,7 @@ insert into package (
     'package2',
     '1.0.0',
     11,
-    generate_package_tsdoc('package2', null, 'description', '{"kw1", "kw2"}', '{"repo2"}', '{"org1"}'),
+    generate_package_tsdoc('package2', null, null, 'description', '{"kw1", "kw2"}', '{"repo2"}', '{"org1"}'),
     true,
     :'repo2ID'
 );
@@ -201,7 +201,7 @@ insert into package (
     :'package3ID',
     'package3',
     '1.0.0',
-    generate_package_tsdoc('package3', null, 'description', '{"kw3"}', '{"repo3"}', '{"org1"}'),
+    generate_package_tsdoc('package3', null, null, 'description', '{"kw3"}', '{"repo3"}', '{"org1"}'),
     :'repo3ID'
 );
 insert into snapshot (

--- a/database/tests/functions/packages/search_packages_monocular.sql
+++ b/database/tests/functions/packages/search_packages_monocular.sql
@@ -28,7 +28,7 @@ insert into package (
     :'package1ID',
     'package1',
     '1.0.0',
-    generate_package_tsdoc('package1', null, 'description', '{"kw1", "kw2"}', '{"repo1"}', '{"user1"}'),
+    generate_package_tsdoc('package1', null, null, 'description', '{"kw1", "kw2"}', '{"repo1"}', '{"user1"}'),
     :'repo1ID'
 );
 insert into snapshot (

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -130,6 +130,7 @@ select columns_are('package', array[
     'package_id',
     'name',
     'normalized_name',
+    'alternative_name',
     'latest_version',
     'stars',
     'tsdoc',

--- a/docs/helm_annotations.md
+++ b/docs/helm_annotations.md
@@ -6,6 +6,12 @@ However, sometimes there might be cases in which it may be useful to provide som
 
 ## Supported annotations
 
+- **artifacthub.io/alternativeName** *(string)*
+
+Sometimes a package can be identified by two similar names. Some examples would be *postgres* / *postgresql* or *mongodb* / *mongo*. Users often may type any of the options and expect the same results. When searching for packages, Artifact Hub gives preference to **exact** matches in names, so sometimes the top results may not be what users would expect. This situation can be improved by providing an alternative name for your package, which will be given the same weight as the package name when indexing. So in cases like the previous examples, it can help ranking them higher in the search results.
+
+*Please note that the alternative name must be a substring of the name, or the name must be a substring of the alternative name.*
+
 - **artifacthub.io/changes** *(yaml string, see example below)*
 
 This annotation is used to provide some details about the changes introduced by a given chart version. Artifact Hub can generate and display a **ChangeLog** based on the entries in the `changes` field in all your chart versions. You can see an example of how the changelog would look like in the Artifact Hub UI [here](https://artifacthub.io/packages/helm/artifact-hub/artifact-hub?modal=changelog).

--- a/docs/metadata/artifacthub-pkg.yml
+++ b/docs/metadata/artifacthub-pkg.yml
@@ -1,6 +1,7 @@
 # Artifact Hub package metadata file
 version: A SemVer 2 version (required)
 name: The name of the package (only alphanum, no spaces, dashes allowed) (required)
+alternativeName: Alternative name of the package (optional)
 displayName: The name of the package nicely formatted (required)
 createdAt: The date this package was created (RFC3339 layout) (required)
 description: A short description of the package (required)

--- a/docs/olm_annotations.md
+++ b/docs/olm_annotations.md
@@ -6,6 +6,12 @@ However, sometimes there might be cases in which it may be useful to provide som
 
 ## Supported annotations
 
+- **artifacthub.io/alternativeName** *(string)*
+
+Sometimes a package can be identified by two similar names. Some examples would be *postgres* / *postgresql* or *mongodb* / *mongo*. Users often may type any of the options and expect the same results. When searching for packages, Artifact Hub gives preference to **exact** matches in names, so sometimes the top results may not be what users would expect. This situation can be improved by providing an alternative name for your package, which will be given the same weight as the package name when indexing. So in cases like the previous examples, it can help ranking them higher in the search results.
+
+*Please note that the alternative name must be a substring of the name, or the name must be a substring of the alternative name.*
+
 - **artifacthub.io/changes** *(yaml string, see example below)*
 
 This annotation is used to provide some details about the changes introduced by a given operator version. Artifact Hub can generate and display a **ChangeLog** based on the entries in the `changes` field in all your operator versions. You can see an example of how the changelog would look like in the Artifact Hub UI [here](https://artifacthub.io/packages/helm/artifact-hub/artifact-hub?modal=changelog).

--- a/docs/tekton_annotations.md
+++ b/docs/tekton_annotations.md
@@ -6,6 +6,12 @@ However, sometimes there might be cases in which it may be useful to provide som
 
 ## Supported annotations
 
+- **artifacthub.io/alternativeName** *(string)*
+
+Sometimes a package can be identified by two similar names. Some examples would be *postgres* / *postgresql* or *mongodb* / *mongo*. Users often may type any of the options and expect the same results. When searching for packages, Artifact Hub gives preference to **exact** matches in names, so sometimes the top results may not be what users would expect. This situation can be improved by providing an alternative name for your package, which will be given the same weight as the package name when indexing. So in cases like the previous examples, it can help ranking them higher in the search results.
+
+*Please note that the alternative name must be a substring of the name, or the name must be a substring of the alternative name.*
+
 - **artifacthub.io/changes** *(yaml string, see example below)*
 
 This annotation is used to provide some details about the changes introduced by a given package version. Artifact Hub can generate and display a **ChangeLog** based on the entries in the `changes` field in all your package versions. You can see an example of how the changelog would look like in the Artifact Hub UI [here](https://artifacthub.io/packages/helm/artifact-hub/artifact-hub?modal=changelog).

--- a/internal/hub/pkg.go
+++ b/internal/hub/pkg.go
@@ -64,6 +64,7 @@ type Package struct {
 	PackageID                      string                 `json:"package_id" hash:"ignore"`
 	Name                           string                 `json:"name"`
 	NormalizedName                 string                 `json:"normalized_name" hash:"ignore"`
+	AlternativeName                string                 `json:"alternative_name"`
 	LogoURL                        string                 `json:"logo_url"`
 	LogoImageID                    string                 `json:"logo_image_id" hash:"ignore"`
 	IsOperator                     bool                   `json:"is_operator"`
@@ -161,6 +162,7 @@ type PackageManager interface {
 type PackageMetadata struct {
 	Version                 string            `yaml:"version"`
 	Name                    string            `yaml:"name"`
+	AlternativeName         string            `yaml:"alternativeName"`
 	DisplayName             string            `yaml:"displayName"`
 	CreatedAt               string            `yaml:"createdAt"`
 	Description             string            `yaml:"description"`

--- a/internal/pkg/manager.go
+++ b/internal/pkg/manager.go
@@ -232,6 +232,11 @@ func (m *Manager) Register(ctx context.Context, pkg *hub.Package) error {
 	if pkg.Name == "" {
 		return fmt.Errorf("%w: %s", hub.ErrInvalidInput, "name not provided")
 	}
+	if pkg.AlternativeName != "" &&
+		!strings.Contains(pkg.Name, pkg.AlternativeName) &&
+		!strings.Contains(pkg.AlternativeName, pkg.Name) {
+		return fmt.Errorf("%w: %s", hub.ErrInvalidInput, "invalid alternative name (must be a subset or superset of the name)")
+	}
 	if pkg.Version == "" {
 		return fmt.Errorf("%w: %s", hub.ErrInvalidInput, "version not provided")
 	}

--- a/internal/pkg/manager_test.go
+++ b/internal/pkg/manager_test.go
@@ -986,6 +986,13 @@ func TestRegister(t *testing.T) {
 				&hub.Package{},
 			},
 			{
+				"invalid alternative name (must be a subset or superset of the name)",
+				&hub.Package{
+					Name:            "package1",
+					AlternativeName: "something else",
+				},
+			},
+			{
 				"version not provided",
 				&hub.Package{
 					Name: "package1",

--- a/internal/pkg/metadata.go
+++ b/internal/pkg/metadata.go
@@ -75,6 +75,7 @@ func PreparePackageFromMetadata(md *hub.PackageMetadata) (*hub.Package, error) {
 	sv, _ := semver.NewVersion(md.Version)
 	p := &hub.Package{
 		Name:                    md.Name,
+		AlternativeName:         md.AlternativeName,
 		IsOperator:              md.Operator,
 		DisplayName:             md.DisplayName,
 		Description:             md.Description,
@@ -122,6 +123,11 @@ func ValidatePackageMetadata(kind hub.RepositoryKind, md *hub.PackageMetadata) e
 	}
 	if md.Name == "" {
 		errs = multierror.Append(errs, fmt.Errorf("%w: %s", ErrInvalidMetadata, "name not provided"))
+	}
+	if md.AlternativeName != "" &&
+		!strings.Contains(md.Name, md.AlternativeName) &&
+		!strings.Contains(md.AlternativeName, md.Name) {
+		errs = multierror.Append(errs, fmt.Errorf("%w: %s", ErrInvalidMetadata, "invalid alternative name (must be a subset or superset of the name)"))
 	}
 	if md.DisplayName == "" {
 		errs = multierror.Append(errs, fmt.Errorf("%w: %s", ErrInvalidMetadata, "display name not provided"))

--- a/internal/pkg/metadata_test.go
+++ b/internal/pkg/metadata_test.go
@@ -246,10 +246,12 @@ func TestValidatePackageMetadata(t *testing.T) {
 			{
 				hub.Keptn,
 				&hub.PackageMetadata{
-					Version: "1.0.0",
-					Name:    "pkg1",
+					Version:         "1.0.0",
+					Name:            "pkg1",
+					AlternativeName: "something else",
 				},
 				[]string{
+					"invalid alternative name (must be a subset or superset of the name)",
 					"invalid metadata: display name not provided",
 					"invalid metadata: createdAt not provided",
 					"invalid metadata: description not provided",

--- a/internal/tracker/source/helm/helm.go
+++ b/internal/tracker/source/helm/helm.go
@@ -36,6 +36,7 @@ import (
 const (
 	concurrency = 10
 
+	alternativeNameAnnotation      = "artifacthub.io/alternativeName"
 	changesAnnotation              = "artifacthub.io/changes"
 	crdsAnnotation                 = "artifacthub.io/crds"
 	crdsExamplesAnnotation         = "artifacthub.io/crdsExamples"
@@ -594,6 +595,11 @@ func extractContainersImages(chrt *chart.Chart) (images []string, err error) {
 // the provided annotations.
 func EnrichPackageFromAnnotations(p *hub.Package, annotations map[string]string) error {
 	var errs *multierror.Error
+
+	// Alternative name
+	if v, ok := annotations[alternativeNameAnnotation]; ok && v != "" {
+		p.AlternativeName = v
+	}
 
 	// Changes
 	if v, ok := annotations[changesAnnotation]; ok {

--- a/internal/tracker/source/olm/olm.go
+++ b/internal/tracker/source/olm/olm.go
@@ -31,6 +31,7 @@ const (
 	isGlobalOperatorKey = "isGlobalOperator"
 
 	// Artifact Hub special annotations
+	alternativeNameAnnotation = "artifacthub.io/alternativeName"
 	changesAnnotation         = "artifacthub.io/changes"
 	imagesWhitelistAnnotation = "artifacthub.io/imagesWhitelist"
 	installAnnotation         = "artifacthub.io/install"
@@ -451,6 +452,11 @@ func PreparePackage(r *hub.Repository, md *Metadata) (*hub.Package, error) {
 	var crdsExamples []interface{}
 	if err := json.Unmarshal([]byte(md.CSV.Annotations["alm-examples"]), &crdsExamples); err == nil {
 		p.CRDsExamples = crdsExamples
+	}
+
+	// Alternative name
+	if v, ok := md.CSV.Annotations[alternativeNameAnnotation]; ok && v != "" {
+		p.AlternativeName = v
 	}
 
 	// Changes

--- a/internal/tracker/source/tekton/tekton.go
+++ b/internal/tracker/source/tekton/tekton.go
@@ -62,6 +62,7 @@ const (
 	TasksKey = "tasks"
 
 	// Keys used for Artifact Hub specific annotations.
+	alternativeNameAnnotation = "artifacthub.io/alternativeName"
 	changesAnnotation         = "artifacthub.io/changes"
 	licenseAnnotation         = "artifacthub.io/license"
 	linksAnnotation           = "artifacthub.io/links"
@@ -526,6 +527,11 @@ func prepareContentAndSourceLinks(i *PreparePackageInput) (string, string) {
 // the provided annotations.
 func enrichPackageFromAnnotations(p *hub.Package, annotations map[string]string) error {
 	var errs *multierror.Error
+
+	// Alternative name
+	if v, ok := annotations[alternativeNameAnnotation]; ok && v != "" {
+		p.AlternativeName = v
+	}
 
 	// Changes
 	if v, ok := annotations[changesAnnotation]; ok {


### PR DESCRIPTION
Sometimes a package can be identified by two similar names. Some examples would be *postgres* / *postgresql* or *mongodb* / *mongo*. Users often may type any of the options and expect the same results. When searching for packages, Artifact Hub gives preference to **exact** matches in names, so sometimes the top results may not be what users would expect. This situation can be improved by providing an alternative name for your package, which will be given the same weight as the package name when indexing. So in cases like the previous examples, it can help ranking them higher in the search results.

Related to #2632

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>