### PR TITLE
fix #2897:  include image.registry for checkDB img

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.13.1-1
+version: 1.13.1-2
 appVersion: 1.13.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io
@@ -83,6 +83,8 @@ annotations:
       description: Harcoded image pull policy in hub deployment
     - kind: fixed
       description: Some other minor bugs and improvements
+    - kind: fixed
+      description: Append registry value from postgres subchart.
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/images: |
     - name: db-migrator

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -91,7 +91,11 @@ Provide an init container to verify the database is accessible
 */}}
 {{- define "chart.checkDbIsReadyInitContainer" -}}
 name: check-db-ready
+{{ if .Values.postgresql.image.registry -}}
 image: {{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+{{- else -}}
+image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+{{- end }}
 imagePullPolicy: {{ .Values.pullPolicy }}
 {{- with .Values.hub.deploy.initContainers.checkDbIsReady.resources }}
 resources:

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Provide an init container to verify the database is accessible
 */}}
 {{- define "chart.checkDbIsReadyInitContainer" -}}
 name: check-db-ready
-image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+image: {{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
 imagePullPolicy: {{ .Values.pullPolicy }}
 {{- with .Values.hub.deploy.initContainers.checkDbIsReady.resources }}
 resources:


### PR DESCRIPTION
When deploying Artifacthub from a corporate registry , registry value is provided in the custom values.yaml. However the checkDbIsReady initcontainer fails to be pulled. 
The image field is constructed the  user provided custom registry value