### PR TITLE
Fix oras command in documentation

### DIFF
--- a/docs/container_images_repositories.md
+++ b/docs/container_images_repositories.md
@@ -67,7 +67,7 @@ Once your repository metadata file is ready, you can push it to the OCI registry
 ```bash
 oras push \
   registry/namespace/repository:artifacthub.io \
-  --manifest-config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+  --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
   artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 ```
 
@@ -88,7 +88,7 @@ The [OCI Artifacts support](https://www.docker.com/blog/announcing-docker-hub-oc
 ```bash
 oras push \
   docker.io/repository:artifacthub.io \
-  --manifest-config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+  --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
   artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 ```
 

--- a/docs/helm_charts_repositories.md
+++ b/docs/helm_charts_repositories.md
@@ -23,7 +23,7 @@ There is an extra Artifact Hub specific metadata file named [artifacthub-repo.ym
 ```bash
 oras push \
   registry/namespace/chart-name:artifacthub.io \
-  --manifest-config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+  --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
   artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 ```
 


### PR DESCRIPTION
There is a breaking change in v0.14.0. Precisely,

`--manifest-config` is renamed to `--config`
`--manifest-annotations` is renamed to `--annotation-file`