### PR TITLE
Update the security process docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,17 @@
 To report a security problem in Artifact Hub, please contact the Maintainers Team
 at <cncf-artifacthub-maintainers@lists.cncf.io>.
 
-The team will help diagnose the severity of the issue and determine how to
-address the issue. Issues deemed to be non-critical will be filed as GitHub
-issues. Critical issues will receive immediate attention and be fixed as quickly
-as possible.
+## Remediation and Notification Process
+
+The maintainers will evaluate the report to verify the security issue. If the
+issue does not have a security impact, the report and follow-up will move to
+GitHub issues. If a security issue exists, the maintainers use the following
+process:
+
+1. Create a new draft advisory via GitHub Security Advisories
+2. Request a CVE identification number
+3. Collaborate on a private fork, part of the GitHub Security Advisory system,
+   to fix the issue.
+4. Once a solution is ready, the CVE will be finalized and published, the change
+   will be merged, and there will be a new release of Artifact Hub including the
+   security fix.


### PR DESCRIPTION
The incubation requirements state, "Clearly documented security processes explaining how to report security issues to the project, and describing how the project provides updated releases or patches to resolve security vulnerabilities"

This change updates the process to add more detail