### PR TITLE
feat: Support custom container registries

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.14.1-2
+version: 1.14.1-3
 appVersion: 1.14.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io
@@ -49,6 +49,8 @@ annotations:
       description: Reduced motion support (accessibility)
     - kind: added
       description: Document how to embed artifacts on other websites
+    - kind: added
+      description: Support for custom image registries
     - kind: changed
       description: Request charts content uncompressed
     - kind: changed

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -27,7 +27,7 @@ spec:
         - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}
       containers:
         - name: db-migrator
-          image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+          image: {{ .Values.dbMigrator.job.image.registry }}/{{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{- with .Values.dbMigrator.job.resources }}
           resources:

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}
         {{- if .Release.IsInstall }}
         - name: check-db-migrator-run
-          image: "{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.repository }}:{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.tag | default (include "chart.KubernetesVersion" . ) }}"
+          image: "{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.registry }}/{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.repository }}:{{ .Values.hub.deploy.initContainers.checkDbMigrator.image.tag | default (include "chart.KubernetesVersion" . ) }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{- with .Values.hub.deploy.initContainers.checkDbMigrator.resources }}
           resources:
@@ -50,7 +50,7 @@ spec:
         {{- end }}
       containers:
         - name: hub
-          image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+          image: {{ .Values.hub.deploy.image.registry }}/{{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           {{- if .Values.hub.server.cacheDir }}
           env:

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -29,7 +29,7 @@ spec:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}
           containers:
             - name: scanner
-              image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+              image: {{ .Values.scanner.cronjob.image.registry }}/{{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
               imagePullPolicy: {{ .Values.pullPolicy }}
               {{- with .Values.scanner.cronjob.resources }}
               resources:

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -28,7 +28,7 @@ spec:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}
           containers:
             - name: tracker
-              image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+              image: {{ .Values.scanner.cronjob.image.registry }}/{{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
               imagePullPolicy: {{ .Values.pullPolicy }}
               {{- with .Values.tracker.cronjob.resources }}
               resources:

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -83,6 +83,8 @@ events:
 dbMigrator:
   job:
     image:
+      # Database migrator image registry
+      registry: docker.io
       # Database migrator image repository (without the tag)
       repository: artifacthub/db-migrator
     # Limits the lifetime of the job after it has finished execution
@@ -130,6 +132,8 @@ hub:
     readinessGates: []
     replicaCount: 1
     image:
+      # Hub image registry
+      registry: docker.io
       # Hub image repository (without the tag)
       repository: artifacthub/hub
     securityContext: {}
@@ -145,6 +149,7 @@ hub:
     initContainers:
       checkDbMigrator:
         image:
+          registry: docker.io
           repository: bitnami/kubectl
           # tag: 1.21
         resources: {}
@@ -294,6 +299,8 @@ scanner:
   enabled: true
   cronjob:
     image:
+      # Scanner image registry
+      registry: docker.io
       # Scanner image repository (without the tag)
       repository: artifacthub/scanner
     securityContext: {}
@@ -324,6 +331,8 @@ scanner:
 tracker:
   cronjob:
     image:
+      # Tracker image registry
+      registry: docker.io
       # Tracker image repository (without the tag)
       repository: artifacthub/tracker
     securityContext: {}


### PR DESCRIPTION
Our internal policy requires us to self-host/-build all container images in our private container registry and to deploy images only from there.

Currently that is not possible using this helm-chart but my changes add the support for setting a custom registry for all images.

FYI: The version change in the `Chart.yaml` might conflict with https://github.com/artifacthub/hub/pull/3254 or https://github.com/artifacthub/hub/pull/3255 depending on which PR might be merged first.