### PR TITLE
feat: Support to use a custom ServiceAccount in all pods

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.14.1-2
+version: 1.14.1-3
 appVersion: 1.14.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io
@@ -49,6 +49,8 @@ annotations:
       description: Reduced motion support (accessibility)
     - kind: added
       description: Document how to embed artifacts on other websites
+    - kind: added
+      description: Support to use a custom ServiceAccount in all pods
     - kind: changed
       description: Request charts content uncompressed
     - kind: changed

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -22,6 +22,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Release.IsInstall }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      {{- end }}
       restartPolicy: Never
       initContainers:
         - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -24,6 +24,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Release.IsInstall }}
+          serviceAccountName: {{ include "chart.serviceAccountName" . }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -23,6 +23,9 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Release.IsInstall }}
+          serviceAccountName: {{ include "chart.serviceAccountName" . }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Release.IsInstall }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: trivy
           image: {{ .Values.trivy.deploy.image }}


### PR DESCRIPTION
Our internal policy requires us to *never* use the default ServiceAccount (to ensure Pods won't get permissions that they don't need). This change would simply let all pods being created by Jobs/CronJobs use the ServiceAccount that would be created by setting `hub.serviceAccount.create: true`.

FYI: The version change in the `Chart.yaml` might conflict with https://github.com/artifacthub/hub/pull/3253 or https://github.com/artifacthub/hub/pull/3255 depending on which PR might be merged first.