### PR TITLE
Replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/domodwyer/mailyak v3.1.1+incompatible
 	github.com/galeone/tensorflow/tensorflow/go v0.0.0-20221023090153-6b7fa0680c3e
 	github.com/galeone/tfgo v0.0.0-20230715013254-16113111dc99
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-enry/go-license-detector/v4 v4.3.1
 	github.com/go-git/go-git/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -349,7 +349,6 @@ github.com/galeone/tensorflow/tensorflow/go v0.0.0-20221023090153-6b7fa0680c3e h
 github.com/galeone/tensorflow/tensorflow/go v0.0.0-20221023090153-6b7fa0680c3e/go.mod h1:TelZuq26kz2jysARBwOrTv16629hyUsHmIoj54QqyFo=
 github.com/galeone/tfgo v0.0.0-20230715013254-16113111dc99 h1:8Bt1P/zy1gb37L4n8CGgp1qmFwBV5729kxVfj0sqhJk=
 github.com/galeone/tfgo v0.0.0-20230715013254-16113111dc99/go.mod h1:3YgYBeIX42t83uP27Bd4bSMxTnQhSbxl0pYSkCDB1tc=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=

--- a/internal/tracker/source/olm/olm.go
+++ b/internal/tracker/source/olm/olm.go
@@ -17,10 +17,10 @@ import (
 	"github.com/artifacthub/hub/internal/hub"
 	"github.com/artifacthub/hub/internal/pkg"
 	"github.com/artifacthub/hub/internal/tracker/source"
-	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/operator-framework/api/pkg/manifests"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/internal/tracker/source/tekton/tekton.go
+++ b/internal/tracker/source/tekton/tekton.go
@@ -18,13 +18,13 @@ import (
 	"github.com/artifacthub/hub/internal/tracker/source"
 	"github.com/artifacthub/hub/internal/tracker/source/generic"
 	"github.com/artifacthub/hub/internal/util"
-	"github.com/ghodss/yaml"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/go-multierror"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	pipelinerun "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	taskrun "github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"sigs.k8s.io/yaml"
 )
 
 const (


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer actively maintained. There are numerous inquiries about the project's status on its issue tracker: https://github.com/ghodss/yaml/issues. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

Since `sigs.k8s.io/yaml` was already a dependency before this pull request was made, we can remove 1 extra dependency by replacing `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`.