### PR TITLE
feat(chart): support nodeSelector for workloads

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Kubernetes packages.
 type: application
-version: 1.16.1-3
+version: 1.16.1-4
 appVersion: 1.16.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -31,6 +31,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (default .Values.nodeSelector .Values.dbMigrator.job.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       initContainers:
         - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -39,6 +39,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (default .Values.nodeSelector .Values.hub.deploy.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Release.IsInstall }}
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -33,6 +33,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (default .Values.nodeSelector .Values.scanner.cronjob.nodeSelector) }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -32,6 +32,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with (default .Values.nodeSelector .Values.tracker.cronjob.nodeSelector) }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -30,6 +30,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (default .Values.nodeSelector .Values.trivy.deploy.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: trivy
           image: {{ .Values.trivy.deploy.image }}

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -95,6 +95,11 @@
                                 "repository"
                             ]
                         },
+                        "nodeSelector": {
+                            "title": "DB migrator pod node selector",
+                            "type": "object",
+                            "default": {}
+                        },
                         "resources": {
                             "title": "DB migrator pod resource requirements",
                             "type": "object",
@@ -345,6 +350,11 @@
                             "title": "Hub pod liveness probe",
                             "type": "object",
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.Probe"
+                        },
+                        "nodeSelector": {
+                            "title": "Hub pod node selector",
+                            "type": "object",
+                            "default": {}
                         },
                         "readinessGates": {
                             "title": "Hub pod readiness gates",
@@ -929,6 +939,11 @@
             "type": "string",
             "default": ""
         },
+        "nodeSelector": {
+            "title": "Default node selector used by pods",
+            "type": "object",
+            "default": {}
+        },
         "pullPolicy": {
             "type": "string",
             "default": "IfNotPresent"
@@ -1004,6 +1019,11 @@
                             "required": [
                                 "repository"
                             ]
+                        },
+                        "nodeSelector": {
+                            "title": "Scanner pod node selector",
+                            "type": "object",
+                            "default": {}
                         },
                         "resources": {
                             "title": "Scanner pod resource requirements",
@@ -1113,6 +1133,11 @@
                                 "repository"
                             ]
                         },
+                        "nodeSelector": {
+                            "title": "Tracker pod node selector",
+                            "type": "object",
+                            "default": {}
+                        },
                         "resources": {
                             "title": "Tracker pod resource requirements",
                             "type": "object",
@@ -1206,6 +1231,11 @@
                             "title": "Trivy container image",
                             "type": "string",
                             "default": "aquasec/trivy:0.44.1"
+                        },
+                        "nodeSelector": {
+                            "title": "Trivy pod node selector",
+                            "type": "object",
+                            "default": {}
                         },
                         "resources": {
                             "title": "Trivy pod resource requirements",

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -4,6 +4,7 @@ imagePullSecrets: []
 imageTag: ""
 nameOverride: ""
 pullPolicy: IfNotPresent
+nodeSelector: {}
 
 # Enable dynamic resource name prefix
 #
@@ -101,6 +102,8 @@ dbMigrator:
     #   requests:
     #     cpu: 100m
     #     memory: 128Mi
+    # Optionally specify a node selector for the dbMigrator pod
+    nodeSelector: {}
   # Load demo user and sample repositories
   loadSampleData: true
   # Directory path where the configuration files should be mounted
@@ -179,6 +182,8 @@ hub:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the hub deployment
     extraVolumeMounts: []
+    # Optionally specify a node selector for the hub deployment
+    nodeSelector: {}
   server:
     # Allow adding private repositories to the Hub
     allowPrivateRepositories: false
@@ -323,6 +328,8 @@ scanner:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the scanner cronjob
     extraVolumeMounts: []
+    # Optionally specify a node selector for the scanner cronjob
+    nodeSelector: {}
   # Number of snapshots to process concurrently
   concurrency: 3
   # Trivy server url. Defaults to the Trivy service's internal URL
@@ -357,6 +364,8 @@ tracker:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the tracker cronjob
     extraVolumeMounts: []
+    # Optionally specify a node selector for the tracker cronjob
+    nodeSelector: {}
   # Cache directory path. If set, the cache directory for the Helm client will be explicitly set (otherwise defaults
   # to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir)
   cacheDir: ""
@@ -396,6 +405,8 @@ trivy:
     extraVolumes: []
     # Optionally specify extra list of additional volume mounts for the trivy deployment
     extraVolumeMounts: []
+    # Optionally specify a node selector for the trivy deployment
+    nodeSelector: {}
   persistence:
     enabled: false
     size: 10Gi


### PR DESCRIPTION
Currently there is no way in the Helm chart to configure Artifact Hub to run on specific nodes in a Kubernetes cluster. This PR adds support for node selectors for each workload (the postgres chart already supports this).