### PR TITLE
feat: Multiple basic auth credentials

### DIFF
--- a/charts/artifact-hub/templates/hub_secret.yaml
+++ b/charts/artifact-hub/templates/hub_secret.yaml
@@ -45,6 +45,12 @@ stringData:
         enabled: {{ .Values.hub.server.basicAuth.enabled }}
         username: {{ .Values.hub.server.basicAuth.username }}
         password: {{ .Values.hub.server.basicAuth.password }}
+      basicAuths:
+        enabled: {{ .Values.hub.server.basicAuths.enabled }}
+        users:
+          {{- range $user, $password := .Values.hub.server.basicAuths.users }}
+          {{ $user }}: {{ $password }}
+          {{- end }}
       cookie:
         hashKey: {{ .Values.hub.server.cookie.hashKey }}
         secure: {{ .Values.hub.server.cookie.secure }}

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -524,6 +524,26 @@
                                 "enabled"
                             ]
                         },
+                        "basicAuths": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "title": "Enable Hub basic auth",
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "users": {
+                                    "title": "map of auth username and passwords",
+                                    "type": "object",
+                                    "default": {
+                                        "hub": "changeme"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "enabled"
+                            ]
+                        },
                         "cookie": {
                             "type": "object",
                             "properties": {

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -205,6 +205,7 @@ hub:
     # Message of the day severity. The color used for the banner will be based on the severity selected
     # Options: "info", "warning", "error"
     motdSeverity: info
+    # basicAuth is deprecated. Please migrate to `basicAuths`
     basicAuth:
       # Enable Hub basic auth
       enabled: false
@@ -212,6 +213,14 @@ hub:
       username: hub
       # Hub basic auth password
       password: changeme
+    # basicAuths allows multiple credentialed users
+    basicAuths:
+      # Enable Hub basic auths
+      enabled: false
+      # Hub basic auth username and passwords
+      users:
+        hub: changeme
+        hub2: changeme2
     cookie:
       # Hub cookie hash key
       hashKey: default-unsafe-key

--- a/configs/hub.yaml
+++ b/configs/hub.yaml
@@ -11,10 +11,16 @@ server:
   shutdownTimeout: 10s
   webBuildPath: ../../web/build
   widgetBuildPath: ../../widget/build
+  # basicAuth is deprecated. Please migrate to `basicAuths`
   basicAuth:
     enabled: false
     username: hub
     password: changeme
+  basicAuths:
+    enabled: false
+    users:
+      hub: changeme
+      hub2: changeme2
   oauth:
     oidc:
       # Dex example app config: https://dexidp.io/docs/getting-started/

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -105,10 +105,16 @@ server:
   shutdownTimeout: 10s
   webBuildPath: ../../web/build
   widgetBuildPath: ../../widget/build
+  # basicAuth is deprecated. Please migrate to `basicAuths
   basicAuth:
     enabled: false
     username: hub
     password: changeme
+  basicAuths:
+    enabled: false
+    users:
+      hub: changeme
+      hub2: changeme2
   cookie:
     hashKey: default-unsafe-key
     secure: false

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -159,7 +159,7 @@ func (h *Handlers) setupRouter() {
 		STSIncludeSubdomains: true,
 		STSPreload:           true,
 	}).Handler)
-	if h.cfg.GetBool("server.basicAuth.enabled") {
+	if h.cfg.GetBool("server.basicAuth.enabled") || h.cfg.GetBool("server.basicAuths.enabled") {
 		r.Use(h.Users.BasicAuth)
 	}
 	r.NotFound(h.Static.Index)

--- a/internal/handlers/user/handlers_test.go
+++ b/internal/handlers/user/handlers_test.go
@@ -168,6 +168,35 @@ func TestBasicAuth(t *testing.T) {
 	})
 }
 
+func TestBasicAuths(t *testing.T) {
+	hw := newHandlersWrapper()
+	hw.cfg.Set("server.basicAuths.enabled", true)
+	hw.cfg.Set("server.basicAuths.users", map[string]string{"test2": "test2"})
+
+	t.Run("without basic auth credentials", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "/", nil)
+		hw.h.BasicAuth(http.HandlerFunc(testsOK)).ServeHTTP(w, r)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("with basic auth credentials", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.SetBasicAuth("test2", "test2")
+		hw.h.BasicAuth(http.HandlerFunc(testsOK)).ServeHTTP(w, r)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
 func TestCheckPasswordStrength(t *testing.T) {
 	t.Run("invalid input", func(t *testing.T) {
 		t.Parallel()

--- a/web/src/api/__fixtures__/index/37.json
+++ b/web/src/api/__fixtures__/index/37.json
@@ -124,6 +124,12 @@
           "password": "changeme",
           "username": "hub"
         },
+        "basicAuths": {
+          "enabled": false,
+          "users": {
+            "hub": "changeme"
+          }
+        },
         "cacheDir": "",
         "configDir": "/home/hub/.cfg",
         "cookie": {

--- a/web/src/layout/package/chartTemplates/Template.test.tsx
+++ b/web/src/layout/package/chartTemplates/Template.test.tsx
@@ -64,6 +64,11 @@ const defaultProps = {
             password: 'changeme',
             username: 'hub',
           },
+          basicAuths: {
+            enabled: false,
+            password: 'changeme',
+            username: 'hub'
+          },
           cacheDir: '',
           configDir: '/home/hub/.cfg',
           cookie: {

--- a/web/src/layout/package/values/index.test.tsx
+++ b/web/src/layout/package/values/index.test.tsx
@@ -115,6 +115,10 @@ hub:
       enabled: false
       username: hub
       password: changeme
+    basicAuths:
+      enabled: false
+      users:
+        hub: changeme
     cookie:
       hashKey: default-unsafe-key
       secure: false


### PR DESCRIPTION
This MR introduces `server.basicAuths` into hub.yaml to enable multiple basic auth credentials.

This is intended to help my organization distribute helm documentation to multiple customers without using a shared credential.

The decision to introduce a new "basicAuths" key, rather than modifying the existing "basicAuth" key, was made to maintain backward compatibility with current configurations. This ensures that deployments remain unaffected unless they explicitly opt-in to the new behavior.