### PR TITLE
Extra containers can now be added to artifacthub pod

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Cloud Native packages.
 type: application
-version: 1.19.1-1
+version: 1.19.1-2
 appVersion: 1.19.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -94,6 +94,9 @@ spec:
           readinessProbe:
             {{- toYaml .Values.hub.deploy.readinessProbe | nindent 12}}
           {{- end }}
+        {{- if .Values.hub.deploy.extraContainers }}
+          {{- include "chart.tplvalues.render" (dict "value" .Values.hub.deploy.extraContainers "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         - name: hub-config
           secret:

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -283,6 +283,12 @@
                             "type": "array",
                             "default": "[]"
                         },
+                        "extraContainers": {
+                            "title": "Extra containers",
+                            "description": "Optionally specify extra list of additional containers for the hub deployment",
+                            "type": "array",
+                            "default": "[]"
+                        },
                         "image": {
                             "type": "object",
                             "properties": {

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -184,6 +184,8 @@ hub:
     extraVolumeMounts: []
     # Optionally specify a node selector for the hub deployment
     nodeSelector: {}
+    # Optionally specify extra list of additional containers for the hub deployment
+    extraContainers: []
   server:
     # Allow adding private repositories to the Hub
     allowPrivateRepositories: false


### PR DESCRIPTION
Added extraContainers list to artifact hub helm chart. This will enable adding sidecars for example oauth-proxy.