### PR TITLE
feat(helm): setting container securityContext, automountServiceAccountToken, serviceAccountName

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Cloud Native packages.
 type: application
-version: 1.21.0-1
+version: 1.21.0-2
 appVersion: 1.20.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -101,6 +101,10 @@ imagePullPolicy: {{ .Values.pullPolicy }}
 resources:
   {{-  toYaml . | nindent 2 }}
 {{- end }}
+{{- with .Values.hub.deploy.initContainers.checkDbIsReady.securityContext }}
+securityContext:
+  {{-  toYaml . | nindent 2 }}
+{{- end }}
 env:
   - name: PGHOST
     value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -17,6 +17,7 @@ metadata:
 {{- end }}
 spec:
   ttlSecondsAfterFinished: {{ .Values.dbMigrator.job.ttlSecondsAfterFinished }}
+  automountServiceAccountToken: {{ .Values.dbMigrator.job.automountServiceAccountToken }}
   template:
     metadata:
       labels:
@@ -25,6 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ .Values.dbMigrator.job.serviceAccountName }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -44,6 +46,10 @@ spec:
         - name: db-migrator
           image: {{ .Values.dbMigrator.job.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- with .Values.dbMigrator.job.containerSecurityContext }}
+          securityContext:
+            {{-  toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.dbMigrator.job.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -56,12 +56,20 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.hub.deploy.initContainers.checkDbMigrator.securityContext }}
+          securityContext:
+            {{-  toYaml . | nindent 12 }}
+          {{- end }}
           command: ['kubectl', 'wait', '--namespace={{ .Release.Namespace }}', '--for=condition=complete', 'job/{{ include "chart.resourceNamePrefix" . }}db-migrator-install', '--timeout=60s']
         {{- end }}
       containers:
         - name: hub
           image: {{ .Values.hub.deploy.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+          {{- with .Values.hub.deploy.containerSecurityContext }}
+          securityContext:
+            {{-  toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.hub.server.cacheDir }}
           env:
             - name: XDG_CACHE_HOME

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -27,6 +27,7 @@ spec:
             {{- toYaml . | nindent 12 }}
         {{- end }}
         spec:
+          serviceAccountName: {{ .Values.scanner.cronjob.serviceAccountName }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
@@ -46,6 +47,10 @@ spec:
             - name: scanner
               image: {{ .Values.scanner.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
               imagePullPolicy: {{ .Values.pullPolicy }}
+              {{- with .Values.scanner.cronjob.containerSecurityContext }}
+              securityContext:
+                {{-  toYaml . | nindent 16 }}
+              {{- end }}
               {{- with .Values.scanner.cronjob.resources }}
               resources:
                 {{- toYaml . | nindent 16 }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -26,6 +26,7 @@ spec:
             {{- toYaml . | nindent 12 }}
         {{- end }}
         spec:
+          serviceAccountName: {{ .Values.tracker.cronjob.serviceAccountName }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
@@ -45,6 +46,10 @@ spec:
             - name: tracker
               image: {{ .Values.tracker.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
               imagePullPolicy: {{ .Values.pullPolicy }}
+              {{- with .Values.tracker.cronjob.containerSecurityContext }}
+              securityContext:
+                {{-  toYaml . | nindent 16 }}
+              {{- end }}
               {{- with .Values.tracker.cronjob.resources }}
               resources:
                 {{- toYaml . | nindent 16 }}

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -1200,6 +1200,17 @@
                             "type": "object",
                             "default": {},
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "containerSecurityContext": {
+                            "title": "Scanner container security context",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "serviceAccountName": {
+                            "title": "Service account name",
+                            "type": "string",
+                            "default": "default"
                         }
                     },
                     "required": [

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -112,6 +112,12 @@
                             "default": {},
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
                         },
+                        "containerSecurityContext": {
+                            "title": "DB migrator container security context",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
                         "ttlSecondsAfterFinished": {
                             "title": "Lifetime after finished execution",
                             "description": "Limits the lifetime of the job after it has finished execution",
@@ -120,6 +126,16 @@
                                 "null",
                                 "integer"
                             ]
+                        },
+                        "automountServiceAccountToken": {
+                            "title": "Automount service account token",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "serviceAccountName": {
+                            "title": "Service account name",
+                            "type": "string",
+                            "default": "default"
                         }
                     },
                     "required": [
@@ -332,6 +348,12 @@
                                             "type": "object",
                                             "default": {},
                                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                                        },
+                                        "securityContext": {
+                                            "title": "Check DB migrator pod security context",
+                                            "type": "object",
+                                            "default": {},
+                                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
                                         }
                                     }
                                 },
@@ -347,6 +369,12 @@
                                             "type": "object",
                                             "default": {},
                                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
+                                        },
+                                        "securityContext": {
+                                            "title": "Check DB readiness pod security context",
+                                            "type": "object",
+                                            "default": {},
+                                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
                                         }
                                     }
                                 }
@@ -389,6 +417,12 @@
                         },
                         "securityContext": {
                             "title": "Hub pod security context",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "containerSecurityContext": {
+                            "title": "Hub container security context",
                             "type": "object",
                             "default": {},
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
@@ -1042,6 +1076,17 @@
                             "type": "object",
                             "default": {},
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "containerSecurityContext": {
+                            "title": "Scanner container security context",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.19.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext"
+                        },
+                        "serviceAccountName": {
+                            "title": "Service account name",
+                            "type": "string",
+                            "default": "default"
                         }
                     },
                     "required": [

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -357,6 +357,8 @@ tracker:
       # Tracker image repository (without the tag)
       repository: artifacthub/tracker
     securityContext: {}
+    containerSecurityContext: {}
+    serviceAccountName: default
     resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -92,7 +92,10 @@ dbMigrator:
     extraPodLabels: {}
     # Limits the lifetime of the job after it has finished execution
     ttlSecondsAfterFinished: null
+    automountServiceAccountToken: true
+    serviceAccountName: default
     securityContext: {}
+    containerSecurityContext: {}
     resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
@@ -141,6 +144,7 @@ hub:
       # Hub image repository (without the tag)
       repository: artifacthub/hub
     securityContext: {}
+    containerSecurityContext: {}
     resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.
@@ -164,6 +168,7 @@ hub:
         #   requests:
         #     cpu: 100m
         #     memory: 128Mi
+        securityContext: {}
       checkDbIsReady:
         resources: {}
         # If you do want to specify resources, uncomment the following
@@ -174,6 +179,7 @@ hub:
         #   requests:
         #     cpu: 100m
         #     memory: 128Mi
+        securityContext: {}
     # Optionally specify extra list of additional labels for the hub deployment
     extraDeploymentLabels: {}
     # Optionally specify extra list of additional labels for hub pods
@@ -313,6 +319,8 @@ scanner:
       # Scanner image repository (without the tag)
       repository: artifacthub/scanner
     securityContext: {}
+    containerSecurityContext: {}
+    serviceAccountName: default
     resources: {}
     # If you do want to specify resources, uncomment the following
     # lines and adjust them as necessary.


### PR DESCRIPTION
We are applying some strict rules to the pods that we deploy in our cluster.
For example we enforce setting `pod.spec.containers.securityContext.capabilities.drop[0].all`

Currently we are only able to set `pod.spec.securityContext` via the helm chart.

Furthermore we are restricting `automountServiceAccountToken` and do not allow the default serviceAccount to be used.

Adding:
- pod.spec.initContainers.securityContext
  - check-db-migrator-run
  - checkDbIsReady
- pod.spec.containers.securityContext
  -  db-migrator-install/upgrade
  - hub
  - tracker
- serviceAccountName
  - db-migrator-install/upgrade
  - tracker
- automountServiceAccountToken
  -  db-migrator-install/upgrade


automountServiceAccountToken & serviceAccountName are beeing set to their respective defaults to not introduce a breaking change