### PR TITLE
fix(helm): moving automountServiceAccountToken to the right place

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Cloud Native packages.
 type: application
-version: 1.21.0-2
+version: 1.21.0-3
 appVersion: 1.20.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -17,7 +17,6 @@ metadata:
 {{- end }}
 spec:
   ttlSecondsAfterFinished: {{ .Values.dbMigrator.job.ttlSecondsAfterFinished }}
-  automountServiceAccountToken: {{ .Values.dbMigrator.job.automountServiceAccountToken }}
   template:
     metadata:
       labels:
@@ -26,6 +25,7 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.dbMigrator.job.automountServiceAccountToken }}
       serviceAccountName: {{ .Values.dbMigrator.job.serviceAccountName }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Moving `automountServiceAccountToken`  from `job.spec.automountServiceAccountToken` to `job.spec.template.spec.automountServiceAccountToken` 