### PR TITLE
Adding tolerations to pods in the Helm Chart

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Cloud Native packages.
 type: application
-version: 1.21.1-0
+version: 1.21.1-1
 appVersion: 1.21.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -39,6 +39,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.dbMigrator.job.tolerations }}
+      tolerations:
+        {{- toYaml .Values.dbMigrator.job.tolerations | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       initContainers:
         - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 10 }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -43,6 +43,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hub.deploy.tolerations }}
+      tolerations:
+        {{- toYaml .Values.hub.deploy.tolerations | nindent 8 }}
+      {{- end }}
       {{- if .Release.IsInstall }}
       serviceAccountName: {{ include "chart.serviceAccountName" . }}
       {{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -40,6 +40,10 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.scanner.cronjob.tolerations }}
+          tolerations:
+            {{- toYaml .Values.scanner.cronjob.tolerations | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -39,6 +39,10 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.tracker.cronjob.tolerations }}
+          tolerations:
+            {{- toYaml .Values.tracker.cronjob.tolerations | nindent 12 }}
+          {{- end }}
           restartPolicy: Never
           initContainers:
             - {{- include "chart.checkDbIsReadyInitContainer" . | nindent 14 }}

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -34,6 +34,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.trivy.deploy.tolerations }}
+      tolerations:
+        {{- toYaml .Values.trivy.deploy.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: trivy
           image: {{ .Values.trivy.deploy.image }}

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -107,6 +107,7 @@ dbMigrator:
     #     memory: 128Mi
     # Optionally specify a node selector for the dbMigrator pod
     nodeSelector: {}
+    tolerations: []
   # Load demo user and sample repositories
   loadSampleData: true
   # Directory path where the configuration files should be mounted
@@ -192,6 +193,7 @@ hub:
     nodeSelector: {}
     # Optionally specify extra list of additional containers for the hub deployment
     extraContainers: []
+    tolerations: []
   server:
     # Allow adding private repositories to the Hub
     allowPrivateRepositories: false
@@ -340,6 +342,7 @@ scanner:
     extraVolumeMounts: []
     # Optionally specify a node selector for the scanner cronjob
     nodeSelector: {}
+    tolerations: []
   # Number of snapshots to process concurrently
   concurrency: 3
   # Trivy server url. Defaults to the Trivy service's internal URL
@@ -378,6 +381,7 @@ tracker:
     extraVolumeMounts: []
     # Optionally specify a node selector for the tracker cronjob
     nodeSelector: {}
+    tolerations: []
   # Cache directory path. If set, the cache directory for the Helm client will be explicitly set (otherwise defaults
   # to $HOME/.cache), and the directory will be mounted as ephemeral volume (emptyDir)
   cacheDir: ""
@@ -419,6 +423,7 @@ trivy:
     extraVolumeMounts: []
     # Optionally specify a node selector for the trivy deployment
     nodeSelector: {}
+    tolerations: []
   persistence:
     enabled: false
     size: 10Gi


### PR DESCRIPTION
As suggested in #4372, adding tolerations to the pods spec of the following templates in the Helm Chart:

trivy_deployment.yaml
tracker_cronjob.yaml
scanner_cronjob.yaml
hub_deployment.yaml
db_migrator_job.yaml