### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -144,8 +144,9 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          system_command "/usr/bin/xattr",
-                         args: ["-dr", "com.apple.quarantine", "#{staged_path}/ah"]
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ah"]
+          end
 
 scoops:
   - description: Artifact Hub command line tool


### PR DESCRIPTION
## PR Summary
This PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/artifacthub/hub/actions/runs/18680123768/job/53259123489#step:9:29): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
dockers and docker_manifests are being phased out and will eventually be replaced by dockers_v2, check https://goreleaser.com/deprecations#dockers for more info
brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
```