### PR TITLE
feat: adds common label support to the helm chart

### DIFF
--- a/charts/artifact-hub/Chart.yaml
+++ b/charts/artifact-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: artifact-hub
 description: Artifact Hub is a web-based application that enables finding, installing, and publishing Cloud Native packages.
 type: application
-version: 1.22.1-0
+version: 1.22.1-1
 appVersion: 1.22.0
 kubeVersion: ">= 1.19.0-0"
 home: https://artifacthub.io

--- a/charts/artifact-hub/templates/_helpers.tpl
+++ b/charts/artifact-hub/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "chart.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app.kubernetes.io/component: hub
         {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.hub.deploy.extraPodLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/artifact-hub/templates/trivy_deployment.yaml
+++ b/charts/artifact-hub/templates/trivy_deployment.yaml
@@ -22,6 +22,9 @@ spec:
       labels:
         app.kubernetes.io/component: trivy
         {{- include "chart.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.trivy.deploy.extraPodLabels }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/artifact-hub/values.schema.json
+++ b/charts/artifact-hub/values.schema.json
@@ -3,6 +3,12 @@
     "title": "Artifact Hub Chart JSON Schema",
     "type": "object",
     "properties": {
+        "commonLabels": {
+            "title": "Common labels",
+            "description": "Labels to add to all kubernetes resources provisioned by the helm chart",
+            "type": "object",
+            "default": {}
+        },
         "creds": {
             "type": "object",
             "properties": {

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -1,5 +1,8 @@
 # Artifact Hub Chart default configuration values
 
+# Common labels to add to all resources
+commonLabels: {}
+
 imagePullSecrets: []
 imageTag: ""
 nameOverride: ""


### PR DESCRIPTION
Fixes #4617 

This PR adds common labels support to the Helm chart, allowing users to specify custom labels that are automatically applied across all Kubernetes resources (Deployment, ConfigMaps, etc.) and pod templates. The implementation adds `commonLabels` field to `values.yaml`, updates the `chart.labels` helper in `_helpers.tpl` to merge these labels, and modifies the deployment.yaml to include `commonLabels` in pod template metadata.