### PR TITLE
feat(chart): add useExistingSecret support for hub, db-migrator, scanner and tracker

### DIFF
--- a/charts/artifact-hub/templates/db_migrator_job.yaml
+++ b/charts/artifact-hub/templates/db_migrator_job.yaml
@@ -75,7 +75,7 @@ spec:
       volumes:
         - name: db-migrator-config
           secret:
-            secretName: {{ include "chart.resourceNamePrefix" . }}db-migrator-config
+            secretName: {{ default (printf "%sdb-migrator-config" (include "chart.resourceNamePrefix" .)) .Values.dbMigrator.useExistingSecret }}
         {{- if .Values.dbMigrator.job.extraVolumes }}
           {{- include "chart.tplvalues.render" (dict "value" .Values.dbMigrator.job.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/artifact-hub/templates/db_migrator_secret.yaml
+++ b/charts/artifact-hub/templates/db_migrator_secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.dbMigrator.useExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,3 +18,4 @@ stringData:
 
     [data]
     loadSampleData = {{ .Values.dbMigrator.loadSampleData }}
+{{- end }}

--- a/charts/artifact-hub/templates/hub_deployment.yaml
+++ b/charts/artifact-hub/templates/hub_deployment.yaml
@@ -120,7 +120,7 @@ spec:
       volumes:
         - name: hub-config
           secret:
-            secretName: {{ include "chart.resourceNamePrefix" . }}hub-config
+            secretName: {{ default (printf "%shub-config" (include "chart.resourceNamePrefix" .)) .Values.hub.useExistingSecret }}
         {{- if .Values.hub.server.cacheDir }}
         - name: cache-dir
           emptyDir: {}

--- a/charts/artifact-hub/templates/hub_secret.yaml
+++ b/charts/artifact-hub/templates/hub_secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.hub.useExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -95,3 +96,4 @@ stringData:
           querystring: {{ .querystring | quote }}
         {{- end }}
       siteName: {{ .Values.hub.theme.siteName | quote }}
+{{- end }}

--- a/charts/artifact-hub/templates/scanner_cronjob.yaml
+++ b/charts/artifact-hub/templates/scanner_cronjob.yaml
@@ -83,7 +83,7 @@ spec:
           volumes:
             - name: scanner-config
               secret:
-                secretName: {{ include "chart.resourceNamePrefix" . }}scanner-config
+                secretName: {{ default (printf "%sscanner-config" (include "chart.resourceNamePrefix" .)) .Values.scanner.useExistingSecret }}
             {{- if .Values.scanner.cacheDir }}
             - name: cache-dir
               emptyDir: {}

--- a/charts/artifact-hub/templates/scanner_secret.yaml
+++ b/charts/artifact-hub/templates/scanner_secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scanner.enabled -}}
+{{- if and .Values.scanner.enabled (not .Values.scanner.useExistingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/artifact-hub/templates/tracker_cronjob.yaml
+++ b/charts/artifact-hub/templates/tracker_cronjob.yaml
@@ -82,7 +82,7 @@ spec:
           volumes:
             - name: tracker-config
               secret:
-                secretName: {{ include "chart.resourceNamePrefix" . }}tracker-config
+                secretName: {{ default (printf "%stracker-config" (include "chart.resourceNamePrefix" .)) .Values.tracker.useExistingSecret }}
             {{- if .Values.tracker.cacheDir }}
             - name: cache-dir
               emptyDir: {}

--- a/charts/artifact-hub/templates/tracker_secret.yaml
+++ b/charts/artifact-hub/templates/tracker_secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tracker.useExistingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -31,3 +32,4 @@ stringData:
       repositoriesKinds: {{ .Values.tracker.repositoriesKinds }}
       bypassDigestCheck: {{ .Values.tracker.bypassDigestCheck }}
       categoryModelPath: ./ml/category/model
+{{- end }}

--- a/charts/artifact-hub/values.yaml
+++ b/charts/artifact-hub/values.yaml
@@ -123,6 +123,10 @@ dbMigrator:
   loadSampleData: true
   # Directory path where the configuration files should be mounted
   configDir: "/home/db-migrator/.cfg"
+  # Name of an existing Secret to use for db-migrator configuration. When set, the chart
+  # will not render its own db-migrator-config Secret. The Secret must contain a key
+  # named 'tern.conf' with the same structure as the chart-generated Secret.
+  useExistingSecret: ""
 
 # Hub configuration
 hub:
@@ -326,6 +330,10 @@ hub:
     # value than the default one (Artifact Hub) is provided, the site enters `white label` mode. In this mode, some
     # sections of the website are displayed in a more generic way, omitting certain parts that are unique to Artifact Hub
     siteName: "Artifact hub"
+  # Name of an existing Secret to use for hub configuration. When set, the chart will
+  # not render its own hub-config Secret. The Secret must contain a key named 'hub.yaml'
+  # with the same structure as the chart-generated Secret.
+  useExistingSecret: ""
 
 # Scanner configuration
 scanner:
@@ -369,6 +377,10 @@ scanner:
   cacheDir: ""
   # Directory path where the configuration files should be mounted
   configDir: "/home/scanner/.cfg"
+  # Name of an existing Secret to use for scanner configuration. When set, the chart
+  # will not render its own scanner-config Secret. The Secret must contain a key named
+  # 'scanner.yaml' with the same structure as the chart-generated Secret.
+  useExistingSecret: ""
 
 # Tracker configuration
 tracker:
@@ -417,6 +429,10 @@ tracker:
   repositoriesKinds: []
   # Bypass digest check. Use this option to force already indexed packages to be reprocessed (use with caution)
   bypassDigestCheck: false
+  # Name of an existing Secret to use for tracker configuration. When set, the chart
+  # will not render its own tracker-config Secret. The Secret must contain a key named
+  # 'tracker.yaml' with the same structure as the chart-generated Secret.
+  useExistingSecret: ""
 
 # Trivy configuration
 trivy:


### PR DESCRIPTION
## Related Issue

Closes #4755 

## Summary

The Helm chart previously always rendered its own Secrets from `values.yaml`, requiring
sensitive values (db password, CSRF key, cookie hash key, OAuth client secrets, SMTP
password, Docker credentials) to be present in plain text. This blocked GitOps-compliant
deployments where secrets are managed externally via tools like SealedSecrets or External
Secrets Operator.

This PR adds an opt-in `useExistingSecret` field per component. When set, the chart skips
rendering its own Secret and references the provided Secret name in the workload instead.
Default behaviour is fully preserved.

## Changes

### `values.yaml`
Added `useExistingSecret: ""` to `hub`, `dbMigrator`, `scanner`, and `tracker` sections
with inline documentation describing the expected Secret key structure.

### Secret templates
Each template is now conditionally skipped when `useExistingSecret` is set:

- `hub_secret.yaml` — guarded by `hub.useExistingSecret`
- `db_migrator_secret.yaml` — guarded by `dbMigrator.useExistingSecret`
- `scanner_secret.yaml` — guarded by `scanner.useExistingSecret` (combined with existing `scanner.enabled` guard)
- `tracker_secret.yaml` — guarded by `tracker.useExistingSecret`

### Workload templates
The hardcoded `secretName` in each volume definition is replaced with a `default` fallback
that uses the provided name when set, or the chart-generated name otherwise:

- `hub_deployment.yaml`
- `db_migrator_job.yaml`
- `scanner_cronjob.yaml`
- `tracker_cronjob.yaml`

## Usage

```yaml
# values.yaml — no plaintext secrets required
hub:
  useExistingSecret: "my-release-hub-config"

dbMigrator:
  useExistingSecret: "my-release-db-migrator-config"

scanner:
  useExistingSecret: "my-release-scanner-config"

tracker:
  useExistingSecret: "my-release-tracker-config"
```

The user-provided Secret must contain the same key as the chart would have generated:

| Component | Required key |
|---|---|
| hub | `hub.yaml` |
| db-migrator | `tern.conf` |
| scanner | `scanner.yaml` |
| tracker | `tracker.yaml` |

## Test plan

- [x] `helm template` with default values produces identical output to before this change
- [x] Setting `hub.useExistingSecret` skips `hub-config` Secret and wires the provided name into the Deployment volume
- [x] Setting `dbMigrator.useExistingSecret` skips `db-migrator-config` Secret and wires the provided name into the Job volume
- [x] Setting `scanner.useExistingSecret` skips `scanner-config` Secret and wires the provided name into the CronJob volume
- [x] Setting `tracker.useExistingSecret` skips `tracker-config` Secret and wires the provided name into the CronJob volume
- [x] All four components can be configured independently
- [x] `scanner.enabled: false` still suppresses both the Secret and the CronJob regardless of `useExistingSecret`
