### PR TITLE
Add collapsible sections to default values view

### DIFF
--- a/web/src/layout/package/values/Values.module.css
+++ b/web/src/layout/package/values/Values.module.css
@@ -83,6 +83,26 @@
 
 [data-line-number] {
   display: block;
+  padding-left: 2rem; /* Room for the section caret */
+}
+
+[data-section-header] {
+  cursor: pointer;
+  background-repeat: no-repeat;
+  background-position: 0.45rem center;
+  background-size: 0.65rem;
+}
+
+[data-section-header][aria-expanded='true'] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%238a9296'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
+}
+
+[data-section-header][aria-expanded='false'] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%238a9296'%3E%3Cpath d='m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z'/%3E%3C/svg%3E");
+}
+
+[data-section-header]:focus {
+  outline: 1px dashed var(--color-black-35);
 }
 
 [data-active-line='true']::before {

--- a/web/src/layout/package/values/ValuesView.test.tsx
+++ b/web/src/layout/package/values/ValuesView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import ValuesView from './ValuesView';
@@ -203,6 +203,82 @@ describe('ValuesView', () => {
 
       expect(updateUrlMock).toHaveBeenCalledTimes(1);
       expect(updateUrlMock).toHaveBeenCalledWith({});
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe('Collapsible sections', () => {
+    const sectionProps = {
+      ...defaultProps,
+      values: 'global:\n  a: 1\n  b:\n    c: 2\n\ndeployment:\n  replicas: 1\n',
+      lines: {
+        1: 'global',
+        2: 'global.a',
+        3: 'global.b',
+        4: 'global.b.c',
+        6: 'deployment',
+        7: 'deployment.replicas',
+      },
+      sections: { 1: 4, 6: 7 },
+    };
+
+    it('renders section headers with aria-expanded', () => {
+      render(<ValuesView {...sectionProps} />);
+
+      expect(document.getElementById('line_1')).toHaveAttribute('data-section-header', 'true');
+      expect(document.getElementById('line_1')).toHaveAttribute('aria-expanded', 'true');
+      expect(document.getElementById('line_2')).not.toHaveAttribute('data-section-header');
+    });
+
+    it('collapses and expands section on gutter click', () => {
+      render(<ValuesView {...sectionProps} />);
+
+      const header = document.getElementById('line_1')!;
+      fireEvent.click(header);
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+      expect(document.getElementById('line_2')).toHaveAttribute('hidden');
+      expect(document.getElementById('line_4')).toHaveAttribute('hidden');
+      expect(document.getElementById('line_6')).not.toHaveAttribute('hidden');
+
+      fireEvent.click(header);
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+      expect(document.getElementById('line_2')).not.toHaveAttribute('hidden');
+    });
+
+    it('still opens copy path dropdown when clicking line content', () => {
+      render(<ValuesView {...sectionProps} />);
+
+      fireEvent.click(screen.getByText(/replicas/));
+      expect(screen.getByRole('button', { name: 'Copy entry path to clipboard' })).toBeInTheDocument();
+    });
+
+    it('toggles section with keyboard', () => {
+      render(<ValuesView {...sectionProps} />);
+
+      const header = document.getElementById('line_1')!;
+      fireEvent.keyDown(header, { key: 'Enter' });
+      expect(header).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.keyDown(header, { key: ' ' });
+      expect(header).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('expands collapsed section containing a deep linked path', () => {
+      jest.useFakeTimers();
+      window.HTMLElement.prototype.scrollTo = jest.fn();
+
+      render(<ValuesView {...sectionProps} visibleValuesPath="global.b.c" />);
+
+      fireEvent.click(document.getElementById('line_1')!);
+      expect(document.getElementById('line_4')).toHaveAttribute('hidden');
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(document.getElementById('line_4')).not.toHaveAttribute('hidden');
+      expect(document.getElementById('line_1')).toHaveAttribute('aria-expanded', 'true');
 
       jest.useRealTimers();
     });

--- a/web/src/layout/package/values/ValuesView.tsx
+++ b/web/src/layout/package/values/ValuesView.tsx
@@ -1,6 +1,13 @@
 import classnames from 'classnames';
 import isUndefined from 'lodash/isUndefined';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 
@@ -14,6 +21,7 @@ import styles from './Values.module.css';
 interface Props {
   values: string;
   lines?: Lines;
+  sections?: Sections;
   normalizedName: string;
   updateUrl: (q: ValuesQuery) => void;
   visibleValuesPath?: string | null;
@@ -23,6 +31,10 @@ interface Lines {
   [key: number]: string;
 }
 
+interface Sections {
+  [keyLine: number]: number;
+}
+
 const ValuesView = (props: Props) => {
   const code = useRef<HTMLDivElement | null>(null);
   const [topPositionMenu, setTopPositionMenu] = useState<number | undefined>();
@@ -30,7 +42,28 @@ const ValuesView = (props: Props) => {
   const [clickedLine, setClickedLine] = useState<number | undefined>();
   const [fullWidth, setFullWidth] = useState<number | undefined>();
   const [activeLine, setActiveLine] = useState<string | undefined>();
+  const [collapsedSections, setCollapsedSections] = useState<number[]>([]);
   const isEmptyValues = props.values === ' ';
+
+  const isSectionHeader = (lineNumber: number): boolean =>
+    !isUndefined(props.sections) && !isUndefined(props.sections[lineNumber]);
+
+  const isLineHidden = (lineNumber: number): boolean =>
+    !isUndefined(props.sections) &&
+    collapsedSections.some((keyLine: number) => lineNumber > keyLine && lineNumber <= (props.sections || {})[keyLine]);
+
+  const toggleSection = (lineNumber: number) => {
+    setCollapsedSections((prev: number[]) =>
+      prev.includes(lineNumber) ? prev.filter((l: number) => l !== lineNumber) : [...prev, lineNumber]
+    );
+  };
+
+  const expandSectionsContaining = (lineNumber: number) => {
+    if (isUndefined(props.sections) || collapsedSections.length === 0) return;
+    setCollapsedSections((prev: number[]) =>
+      prev.filter((keyLine: number) => !(lineNumber > keyLine && lineNumber <= props.sections![keyLine]))
+    );
+  };
 
   const cleanClickedLine = () => {
     setClickedLine(undefined);
@@ -60,7 +93,10 @@ const ValuesView = (props: Props) => {
     };
 
     if (!isUndefined(activeLine)) {
-      scrollIntoView(activeLine);
+      expandSectionsContaining(parseInt(activeLine));
+      // Wait for collapsed sections to expand before scrolling
+      const timeout = setTimeout(() => scrollIntoView(activeLine), 50);
+      return () => clearTimeout(timeout);
     }
   }, [activeLine]);
 
@@ -175,21 +211,41 @@ const ValuesView = (props: Props) => {
               showLineNumbers
               wrapLines
               lineProps={(lineNumber) => {
+                const isHeader = isSectionHeader(lineNumber);
+                const onLineClick = (e: ReactMouseEvent<HTMLElement>) => {
+                  // Clicks on the line wrapper itself (not its content) toggle the section
+                  if (isHeader && e.target === e.currentTarget) {
+                    toggleSection(lineNumber);
+                    return;
+                  }
+                  const isClicked = clickedLine === lineNumber;
+                  if (props.lines && !isUndefined(props.lines[lineNumber]) && !isClicked) {
+                    setClickedLine(lineNumber);
+                  } else {
+                    cleanClickedLine();
+                  }
+                };
+                const onLineKeyDown = (e: ReactKeyboardEvent<HTMLElement>) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    toggleSection(lineNumber);
+                  }
+                };
                 return {
                   id: `line_${lineNumber}`,
                   className: 'line',
+                  hidden: isLineHidden(lineNumber),
                   style: { position: 'relative', width: fullWidth ? `${fullWidth}px` : 'auto' },
                   'data-line-number': lineNumber,
                   'data-clickable-line': props.lines && props.lines[lineNumber] ? 'true' : 'false',
                   'data-active-line': lineNumber === clickedLine,
-                  onClick() {
-                    const isClicked = clickedLine === lineNumber;
-                    if (props.lines && !isUndefined(props.lines[lineNumber]) && !isClicked) {
-                      setClickedLine(lineNumber);
-                    } else {
-                      cleanClickedLine();
-                    }
-                  },
+                  onClick: onLineClick,
+                  ...(isHeader && {
+                    'data-section-header': 'true',
+                    'aria-expanded': !collapsedSections.includes(lineNumber),
+                    tabIndex: 0,
+                    onKeyDown: onLineKeyDown,
+                  }),
                 };
               }}
             >

--- a/web/src/layout/package/values/index.test.tsx
+++ b/web/src/layout/package/values/index.test.tsx
@@ -6,7 +6,7 @@ import { vi } from 'vitest';
 import API from '../../../api';
 import { ErrorKind } from '../../../types';
 import alertDispatcher from '../../../utils/alertDispatcher';
-import Values from './';
+import Values, { getValuesData } from './';
 vi.mock('../../../api');
 vi.mock('../../../utils/alertDispatcher');
 
@@ -570,5 +570,34 @@ describe('Values', () => {
         });
       });
     });
+  });
+});
+
+describe('getValuesData', () => {
+  it('computes sections only for keys with nested content', () => {
+    const values = [
+      'global:', // 1
+      '  a: 1', // 2
+      '  b:', // 3
+      '    c: 2', // 4
+      '', // 5
+      'deployment:', // 6
+      '  replicas: 1', // 7
+      '  # comment for empty', // 8
+      '  empty: []', // 9
+      'scalar: true', // 10
+      '# leading comment for list', // 11
+      'list:', // 12
+      '  - x: 1', // 13
+      '  - y: 2', // 14
+    ].join('\n');
+
+    const { lines, sections } = getValuesData(values);
+
+    expect(lines[1]).toBe('global');
+    expect(lines[3]).toBe('global.b');
+    expect(lines[9]).toBe('deployment.empty');
+    expect(lines[12]).toBe('list');
+    expect(sections).toEqual({ 1: 4, 3: 4, 6: 9, 12: 14 });
   });
 });

--- a/web/src/layout/package/values/index.tsx
+++ b/web/src/layout/package/values/index.tsx
@@ -33,11 +33,16 @@ interface Lines {
   [key: number]: string;
 }
 
+export interface Sections {
+  [keyLine: number]: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getPathsPerLine = (values: any): Lines => {
+export const getValuesData = (values: any): { lines: Lines; sections: Sections } => {
   const lineCounter = new LineCounter();
   const doc = parseDocument(values, { lineCounter });
   const lines: Lines = {};
+  const sections: Sections = {};
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const extractKeys = (elem: any, path?: string) => {
@@ -50,6 +55,10 @@ const getPathsPerLine = (values: any): Lines => {
           const currentPath = getJMESPathForValuesSchema(item.key.value, path);
           const line = lineCounter.linePos(item.key.range[0]).line;
           lines[line] = currentPath;
+          if ((isMap(item.value) || isSeq(item.value)) && item.value.items.length > 0 && item.value.range) {
+            const endLine = lineCounter.linePos(item.value.range[2] - 1).line;
+            if (endLine > line) sections[line] = endLine;
+          }
           extractKeys(item.value, currentPath);
         });
       } else if (isSeq(elem)) {
@@ -62,7 +71,7 @@ const getPathsPerLine = (values: any): Lines => {
   };
 
   extractKeys(doc);
-  return lines;
+  return { lines, sections };
 };
 
 const Values = (props: Props) => {
@@ -73,6 +82,7 @@ const Values = (props: Props) => {
   const [currentPkgId, setCurrentPkgId] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [lines, setLines] = useState<Lines | undefined>();
+  const [sections, setSections] = useState<Sections | undefined>();
   const [enabledDiff, setEnabledDiff] = useState<boolean>(
     !isUndefined(props.compareVersionTo) && !isNull(props.compareVersionTo)
   );
@@ -112,7 +122,9 @@ const Values = (props: Props) => {
       setIsLoading(true);
       const data = await API.getChartValues(props.packageId, props.version);
       setValues(data || ' ');
-      setLines(getPathsPerLine(data));
+      const { lines: valuesLines, sections: valuesSections } = getValuesData(data);
+      setLines(valuesLines);
+      setSections(valuesSections);
       setCurrentPkgId(props.packageId);
       setIsLoading(false);
       setOpenStatus(true);
@@ -313,6 +325,7 @@ const Values = (props: Props) => {
                   <ValuesView
                     values={values}
                     lines={lines}
+                    sections={sections}
                     normalizedName={props.normalizedName}
                     updateUrl={updateUrl}
                     visibleValuesPath={props.visibleValuesPath}


### PR DESCRIPTION
This PR adds support for collapsing sections in the chart's default values modal.

- Keys with nested content (maps and lists, at any depth) are collapsible, expanded by default, toggled by clicking the caret next to the line (keyboard: Enter/Space)
- Clicking the line content still opens the entry path dropdown
- Search results and deep links (`?modal=values&path=...`) automatically expand the sections containing the target line
- Collapsing a section only hides its nested content; comments introducing the next key remain visible

Section boundaries are computed from the values file YAML AST (already parsed for the entry paths), so no extra dependencies are needed.